### PR TITLE
Check for null in LootingLevelEvent

### DIFF
--- a/src/main/java/leaf/cosmere/effects/feruchemy/store/ChromiumStoreEffect.java
+++ b/src/main/java/leaf/cosmere/effects/feruchemy/store/ChromiumStoreEffect.java
@@ -33,6 +33,9 @@ public class ChromiumStoreEffect extends FeruchemyEffectBase
 
     public void onLootingLevelEvent(LootingLevelEvent event)
     {
+        if (event.getDamageSource() == null)
+            return;
+    
         boolean isRemote = event.getEntityLiving().world.isRemote;
         boolean entityNotLiving = !(event.getDamageSource().getTrueSource() instanceof LivingEntity);
 


### PR DESCRIPTION
Unfortunately, due to interactions with global loot modifiers, the damage source can be null in LootingLevelEvent. This fix avoids a potential null pointer exception by checking to make sure that the damage source is indeed not null.