### PR TITLE
[Allomancy][Feruchemy] Atium requires electrum powers

### DIFF
--- a/src/allomancy/java/leaf/cosmere/allomancy/common/eventHandlers/AllomancyModBusEventHandler.java
+++ b/src/allomancy/java/leaf/cosmere/allomancy/common/eventHandlers/AllomancyModBusEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 8 - 10 - 2022 ~ Leaf
+ * File updated ~ 2 - 11 - 2022 ~ Leaf
  */
 
 package leaf.cosmere.allomancy.common.eventHandlers;
@@ -46,7 +46,7 @@ public class AllomancyModBusEventHandler
 		{
 			for (Metals.MetalType metalType : Metals.MetalType.values())
 			{
-				if (metalType.hasAssociatedManifestation())
+				if (metalType.hasAssociatedManifestation() && AllomancyAttributes.ALLOMANCY_ATTRIBUTES.containsKey(metalType))
 				{
 					event.add(entityType, AllomancyAttributes.ALLOMANCY_ATTRIBUTES.get(metalType).get());
 				}

--- a/src/allomancy/java/leaf/cosmere/allomancy/common/manifestation/AllomancyAtium.java
+++ b/src/allomancy/java/leaf/cosmere/allomancy/common/manifestation/AllomancyAtium.java
@@ -1,14 +1,16 @@
 /*
- * File updated ~ 8 - 10 - 2022 ~ Leaf
+ * File updated ~ 10 - 1 - 2023 ~ Leaf
  */
 
 package leaf.cosmere.allomancy.common.manifestation;
 
+import leaf.cosmere.allomancy.common.registries.AllomancyAttributes;
 import leaf.cosmere.allomancy.common.registries.AllomancyManifestations;
 import leaf.cosmere.api.Metals;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 
@@ -19,6 +21,12 @@ public class AllomancyAtium extends AllomancyManifestation
 		super(metalType);
 
 
+	}
+
+	@Override
+	public Attribute getAttribute()
+	{
+		return AllomancyAttributes.ALLOMANCY_ATTRIBUTES.get(Metals.MetalType.ELECTRUM).getAttribute();
 	}
 
 	@Override

--- a/src/allomancy/java/leaf/cosmere/allomancy/common/registries/AllomancyAttributes.java
+++ b/src/allomancy/java/leaf/cosmere/allomancy/common/registries/AllomancyAttributes.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 24 - 10 - 2022 ~ Leaf
+ * File updated ~ 31 - 10 - 2022 ~ Leaf
  */
 
 package leaf.cosmere.allomancy.common.registries;
@@ -21,7 +21,7 @@ public class AllomancyAttributes
 
 	public static final Map<Metals.MetalType, AttributeRegistryObject<Attribute>> ALLOMANCY_ATTRIBUTES =
 			Arrays.stream(Metals.MetalType.values())
-					.filter(Metals.MetalType::hasAssociatedManifestation)
+					.filter(metalType -> metalType != Metals.MetalType.ATIUM && metalType.hasAssociatedManifestation())
 					.collect(Collectors.toMap(
 							Function.identity(),
 							type ->

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/eventHandlers/FeruchemyModBusEventHandler.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/eventHandlers/FeruchemyModBusEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 8 - 10 - 2022 ~ Leaf
+ * File updated ~ 2 - 11 - 2022 ~ Leaf
  */
 
 package leaf.cosmere.feruchemy.common.eventHandlers;
@@ -46,7 +46,7 @@ public class FeruchemyModBusEventHandler
 		{
 			for (Metals.MetalType metalType : Metals.MetalType.values())
 			{
-				if (metalType.hasAssociatedManifestation())
+				if (metalType.hasAssociatedManifestation() && FeruchemyAttributes.FERUCHEMY_ATTRIBUTES.containsKey(metalType))
 				{
 					event.add(entityType, FeruchemyAttributes.FERUCHEMY_ATTRIBUTES.get(metalType).get());
 				}

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyAtium.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyAtium.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 8 - 10 - 2022 ~ Leaf
+ * File updated ~ 31 - 10 - 2022 ~ Leaf
  */
 
 package leaf.cosmere.feruchemy.common.manifestation;
@@ -8,6 +8,7 @@ import leaf.cosmere.api.Metals;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.common.registration.impl.AttributeRegistryObject;
 import leaf.cosmere.common.registry.AttributesRegistry;
+import leaf.cosmere.feruchemy.common.registries.FeruchemyAttributes;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
@@ -17,6 +18,13 @@ public class FeruchemyAtium extends FeruchemyManifestation
 	public FeruchemyAtium(Metals.MetalType metalType)
 	{
 		super(metalType);
+	}
+
+
+	@Override
+	public Attribute getAttribute()
+	{
+		return FeruchemyAttributes.FERUCHEMY_ATTRIBUTES.get(Metals.MetalType.ELECTRUM).getAttribute();
 	}
 
 	@Override

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/registries/FeruchemyAttributes.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/registries/FeruchemyAttributes.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 24 - 10 - 2022 ~ Leaf
+ * File updated ~ 31 - 10 - 2022 ~ Leaf
  */
 
 package leaf.cosmere.feruchemy.common.registries;
@@ -21,7 +21,7 @@ public class FeruchemyAttributes
 
 	public static final Map<Metals.MetalType, AttributeRegistryObject<Attribute>> FERUCHEMY_ATTRIBUTES =
 			Arrays.stream(Metals.MetalType.values())
-					.filter(Metals.MetalType::hasAssociatedManifestation)
+					.filter(metalType -> metalType != Metals.MetalType.ATIUM && metalType.hasAssociatedManifestation())
 					.collect(Collectors.toMap(
 							Function.identity(),
 							type ->

--- a/src/surgebinding/java/leaf/cosmere/surgebinding/common/manifestation/SurgeGravitation.java
+++ b/src/surgebinding/java/leaf/cosmere/surgebinding/common/manifestation/SurgeGravitation.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 28 - 10 - 2022 ~ Leaf
+ * File updated ~ 1 - 2 - 2023 ~ Leaf
  */
 
 package leaf.cosmere.surgebinding.common.manifestation;
@@ -38,11 +38,11 @@ public class SurgeGravitation extends SurgebindingManifestation
 
 					SurgebindingSpiritwebSubmodule submodule = (SurgebindingSpiritwebSubmodule) ((SpiritwebCapability) iSpiritweb).spiritwebSubmodules.get(Manifestations.ManifestationTypes.SURGEBINDING);
 
-					if (submodule.adjustStormlight(20, true))
+					if (submodule.adjustStormlight(-20, true))
 					{
 						final LivingEntity entity = event.getEntity();
 						CosmereAPI.logger.info("%s has launched %s into the sky".formatted(player.getName().getString(), entity.getName().getString()));
-						
+
 						entity.stopRiding();
 						entity.setPos(event.getEntity().getX(), event.getEntity().getY() + 0.1d, event.getEntity().getZ());
 						entity.setOnGround(false);


### PR DESCRIPTION
## Changes proposed in this pull request:

Basically changing things so that atium is not it's own separate power, but instead matches canon that electrum users can automatically use it. 

This is obviously making the assumption that all atium in the mod is the electrum alloy with 'pure' atium.