### PR TITLE
Fixes a gamebreaking bug that would kick players from a server if they enabled a sandmastery mode

### DIFF
--- a/src/allomancy/java/leaf/cosmere/allomancy/common/manifestation/AllomancyIronSteel.java
+++ b/src/allomancy/java/leaf/cosmere/allomancy/common/manifestation/AllomancyIronSteel.java
@@ -57,6 +57,7 @@ public class AllomancyIronSteel extends AllomancyManifestation
 	@Override
 	public void applyEffectTick(ISpiritweb data)
 	{
+		System.out.println(data.getLiving().level.isClientSide);
 		if (data.getLiving().level.isClientSide)
 		{
 			performEffectClient(data);

--- a/src/main/java/leaf/cosmere/common/cap/entity/SpiritwebCapability.java
+++ b/src/main/java/leaf/cosmere/common/cap/entity/SpiritwebCapability.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import leaf.cosmere.api.CosmereAPI;
 import leaf.cosmere.api.ISpiritwebSubmodule;
 import leaf.cosmere.api.Manifestations;
+import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.api.manifestation.Manifestation;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.common.Cosmere;

--- a/src/main/java/leaf/cosmere/common/cap/entity/SpiritwebCapability.java
+++ b/src/main/java/leaf/cosmere/common/cap/entity/SpiritwebCapability.java
@@ -238,7 +238,7 @@ public class SpiritwebCapability implements ISpiritweb
 		{
 			//attribute registry name is now the same as the manifestation registry name, so this function
 			//doesn't need to be able to access the attribute registries of sub mods :)
-			Attribute attribute = ForgeRegistries.ATTRIBUTES.getValue(manifestation.getRegistryName());
+			Attribute attribute = manifestation.getAttribute();
 			if (attribute != null)
 			{
 				AttributeInstance oldAttr = oldAttMap.getInstance(attribute);

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/capabilities/SandmasterySpiritwebSubmodule.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/capabilities/SandmasterySpiritwebSubmodule.java
@@ -5,9 +5,13 @@
 package leaf.cosmere.sandmastery.common.capabilities;
 
 import leaf.cosmere.api.ISpiritwebSubmodule;
+import leaf.cosmere.api.Metals;
+import leaf.cosmere.api.Taldain;
 import leaf.cosmere.api.manifestation.Manifestation;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
+import leaf.cosmere.sandmastery.common.manifestation.MasteryCushion;
 import leaf.cosmere.sandmastery.common.manifestation.SandmasteryManifestation;
+import leaf.cosmere.sandmastery.common.registries.SandmasteryManifestations;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
@@ -26,6 +30,8 @@ public class SandmasterySpiritwebSubmodule implements ISpiritwebSubmodule
 	@Override
 	public void tickClient(ISpiritweb spiritweb)
 	{
+		MasteryCushion cushion = (MasteryCushion) SandmasteryManifestations.SANDMASTERY_POWERS.get(Taldain.Mastery.CUSHION).get();
+		cushion.tickClient(spiritweb);
 	}
 
 	@Override

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/items/SandJarItem.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/items/SandJarItem.java
@@ -8,7 +8,6 @@ import leaf.cosmere.sandmastery.common.blocks.SandJarBlock;
 import leaf.cosmere.sandmastery.common.blocks.TaldainSandLayerBlock;
 import leaf.cosmere.sandmastery.common.itemgroups.SandmasteryItemGroups;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryBlocksRegistry;
-import leaf.cosmere.sandmastery.common.registries.SandmasteryDimensions;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryItems;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
 import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
@@ -37,7 +36,7 @@ public class SandJarItem extends ChargeableItemBase {
 
     @Override
     public int getMaxCharge(ItemStack itemStack) {
-        return Mth.floor(SandmasteryConstants.chargePerLayerOfSand);
+        return Mth.floor(SandmasteryConstants.CHARGE_PER_SAND_LAYER);
     }
 
     @Override

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryCushion.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryCushion.java
@@ -22,8 +22,11 @@ public class MasteryCushion extends SandmasteryManifestation {
     @Override
     public void tick(ISpiritweb data)
     {
-        int mode = getMode(data);
-        if(MiscHelper.isClient(data)) performEffectServer(data);
+        if(getMode(data) > 0) performEffectServer(data);
+    }
+
+    public void tickClient(ISpiritweb data) {
+        if(MiscHelper.isClient(data)) performEffectClient(data);
     }
 
     protected void performEffectServer(ISpiritweb data)

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryCushion.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryCushion.java
@@ -10,8 +10,11 @@ import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodul
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.util.thread.SidedThreadGroups;
 
-public class MasteryCushion extends SandmasteryManifestation{
+public class MasteryCushion extends SandmasteryManifestation {
     public MasteryCushion(Taldain.Mastery mastery) {
         super(mastery);
     }
@@ -20,18 +23,10 @@ public class MasteryCushion extends SandmasteryManifestation{
     public void tick(ISpiritweb data)
     {
         int mode = getMode(data);
-        if (mode > 0) {
-            applyEffectTick(data);
-        }
+        if(MiscHelper.isClient(data)) performEffectServer(data);
     }
 
-    @Override
-    public void applyEffectTick(ISpiritweb data)
-    {
-        performEffectServer(data);
-    }
-
-    private void performEffectServer(ISpiritweb data)
+    protected void performEffectServer(ISpiritweb data)
     {
         SpiritwebCapability playerSpiritweb = (SpiritwebCapability) data;
         SandmasterySpiritwebSubmodule submodule = (SandmasterySpiritwebSubmodule) playerSpiritweb.spiritwebSubmodules.get(Manifestations.ManifestationTypes.SANDMASTERY);

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryElevate.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryElevate.java
@@ -2,14 +2,18 @@ package leaf.cosmere.sandmastery.common.manifestation;
 
 import leaf.cosmere.api.Manifestations;
 import leaf.cosmere.api.Taldain;
+import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
-import leaf.cosmere.client.Keybindings;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.sandmastery.client.SandmasteryKeybindings;
 import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodule;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
+import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.util.thread.SidedThreadGroups;
 
 public class MasteryElevate extends SandmasteryManifestation{
     public MasteryElevate(Taldain.Mastery mastery) {
@@ -19,19 +23,16 @@ public class MasteryElevate extends SandmasteryManifestation{
     @Override
     public void tick(ISpiritweb data)
     {
-        int mode = getMode(data);
-        if (mode > 0 && (MiscHelper.isActivatedAndActive(data, this) || SandmasteryKeybindings.SANDMASTERY_ELEVATE.isDown())) {
-            applyEffectTick(data);
-        }
+        if(MiscHelper.isClient(data)) performEffectClient(data);
+
+        int hotkeyFlags = CompoundNBTHelper.getOrCreate(data.getCompoundTag(), "sandmastery").getInt("hotkeys");
+        boolean enabledViaHotkey = false;
+        if((hotkeyFlags & SandmasteryConstants.elevateFlagVal) != 0) enabledViaHotkey = true;
+        if((hotkeyFlags & 1) != 0) enabledViaHotkey = true;
+        if(getMode(data) > 0 && enabledViaHotkey) performEffectServer(data);
     }
 
-    @Override
-    public void applyEffectTick(ISpiritweb data)
-    {
-        performEffectServer(data);
-    }
-
-    private void performEffectServer(ISpiritweb data)
+    protected void performEffectServer(ISpiritweb data)
     {
         SpiritwebCapability playerSpiritweb = (SpiritwebCapability) data;
         SandmasterySpiritwebSubmodule submodule = (SandmasterySpiritwebSubmodule) playerSpiritweb.spiritwebSubmodules.get(Manifestations.ManifestationTypes.SANDMASTERY);

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryElevate.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryElevate.java
@@ -1,3 +1,7 @@
+/*
+ * File updated ~ 9 - 2 - 2023 ~ Leaf
+ */
+
 package leaf.cosmere.sandmastery.common.manifestation;
 
 import leaf.cosmere.api.Manifestations;
@@ -5,55 +9,81 @@ import leaf.cosmere.api.Taldain;
 import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
-import leaf.cosmere.sandmastery.client.SandmasteryKeybindings;
 import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodule;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
 import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.fml.util.thread.SidedThreadGroups;
 
-public class MasteryElevate extends SandmasteryManifestation {
-    public MasteryElevate(Taldain.Mastery mastery) {
-        super(mastery);
-    }
+public class MasteryElevate extends SandmasteryManifestation
+{
+	public MasteryElevate(Taldain.Mastery mastery)
+	{
+		super(mastery);
+	}
 
-    @Override
-    public void tick(ISpiritweb data)
-    {
-        int hotkeyFlags = CompoundNBTHelper.getOrCreate(data.getCompoundTag(), "sandmastery").getInt("hotkeys");
-        boolean enabledViaHotkey = false;
-        if((hotkeyFlags & SandmasteryConstants.elevateFlagVal) != 0) enabledViaHotkey = true;
-        if((hotkeyFlags & 1) != 0) enabledViaHotkey = true;
+	@Override
+	public void tick(ISpiritweb data)
+	{
+		final CompoundTag dataTag = data.getCompoundTag();
+		final CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(dataTag, "sandmastery");
+		int hotkeyFlags = sandmasteryTag.getInt("hotkeys");
+		boolean enabledViaHotkey = false;
+		if ((hotkeyFlags & SandmasteryConstants.elevateFlagVal) != 0)
+		{
+			enabledViaHotkey = true;
+		}
+		if ((hotkeyFlags & 1) != 0)
+		{
+			enabledViaHotkey = true;
+		}
 
-        if(!MiscHelper.isClient(data)) MiscHelper.logToChat(data,"Serverside flags: " + hotkeyFlags);
+		if (!MiscHelper.isClient(data))
+		{
+			MiscHelper.logToChat(data, "Serverside flags: " + hotkeyFlags);
+		}
 
-        if(getMode(data) > 0 && enabledViaHotkey) performEffectServer(data);
-    }
+		if (getMode(data) > 0 && enabledViaHotkey)
+		{
+			performEffectServer(data);
+		}
+	}
 
-    protected void performEffectServer(ISpiritweb data)
-    {
-        SpiritwebCapability playerSpiritweb = (SpiritwebCapability) data;
-        SandmasterySpiritwebSubmodule submodule = (SandmasterySpiritwebSubmodule) playerSpiritweb.spiritwebSubmodules.get(Manifestations.ManifestationTypes.SANDMASTERY);
+	protected void performEffectServer(ISpiritweb data)
+	{
+		SpiritwebCapability playerSpiritweb = (SpiritwebCapability) data;
+		SandmasterySpiritwebSubmodule submodule = (SandmasterySpiritwebSubmodule) playerSpiritweb.spiritwebSubmodules.get(Manifestations.ManifestationTypes.SANDMASTERY);
 
-        if(getMode(data) < 3) return; // It's shown in White Sand that one can't lift themselves with fewer than 3 ribbons
-        if(!submodule.adjustHydration(-10, false)) return; // Too dehydrated to use sand mastery
-        if(!enoughChargedSand(data)) return;
+		if (getMode(data) < 3)
+		{
+			return; // It's shown in White Sand that one can't lift themselves with fewer than 3 ribbons
+		}
+		if (!submodule.adjustHydration(-10, false))
+		{
+			return; // Too dehydrated to use sand mastery
+		}
+		if (!enoughChargedSand(data))
+		{
+			return;
+		}
 
-        LivingEntity living = data.getLiving();
-        int distFromGround = MiscHelper.distanceFromGround(living);
-        int maxLift = getMode(data)*4;
-        if(distFromGround > maxLift) return;
+		LivingEntity living = data.getLiving();
+		int distFromGround = MiscHelper.distanceFromGround(living);
+		int maxLift = getMode(data) * 4;
+		if (distFromGround > maxLift)
+		{
+			return;
+		}
 
 
-        Vec3 direction = (maxLift - distFromGround) > 3 ? new Vec3(0, 0.75, 0) : new Vec3(0, 0.15, 0);;
-        living.setDeltaMovement(direction);
-        living.hurtMarked = true; // Allow the game to move the player
-        living.resetFallDistance();
+		Vec3 direction = (maxLift - distFromGround) > 3 ? new Vec3(0, 0.75, 0) : new Vec3(0, 0.15, 0);
 
-        submodule.adjustHydration(-10, true);
-        useChargedSand(data);
-    }
+		living.setDeltaMovement(direction);
+		living.hurtMarked = true; // Allow the game to move the player
+		living.resetFallDistance();
+
+		submodule.adjustHydration(-10, true);
+		useChargedSand(data);
+	}
 }

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryElevate.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryElevate.java
@@ -6,13 +6,11 @@ package leaf.cosmere.sandmastery.common.manifestation;
 
 import leaf.cosmere.api.Manifestations;
 import leaf.cosmere.api.Taldain;
-import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodule;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
 import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
 
@@ -26,24 +24,7 @@ public class MasteryElevate extends SandmasteryManifestation
 	@Override
 	public void tick(ISpiritweb data)
 	{
-		final CompoundTag dataTag = data.getCompoundTag();
-		final CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(dataTag, "sandmastery");
-		int hotkeyFlags = sandmasteryTag.getInt("hotkeys");
-		boolean enabledViaHotkey = false;
-		if ((hotkeyFlags & SandmasteryConstants.elevateFlagVal) != 0)
-		{
-			enabledViaHotkey = true;
-		}
-		if ((hotkeyFlags & 1) != 0)
-		{
-			enabledViaHotkey = true;
-		}
-
-		if (!MiscHelper.isClient(data))
-		{
-			MiscHelper.logToChat(data, "Serverside flags: " + hotkeyFlags);
-		}
-
+		boolean enabledViaHotkey = MiscHelper.enabledViaHotkey(data, SandmasteryConstants.ELEVATE_HOTKEY_FLAG);
 		if (getMode(data) > 0 && enabledViaHotkey)
 		{
 			performEffectServer(data);

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryElevate.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryElevate.java
@@ -15,7 +15,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.util.thread.SidedThreadGroups;
 
-public class MasteryElevate extends SandmasteryManifestation{
+public class MasteryElevate extends SandmasteryManifestation {
     public MasteryElevate(Taldain.Mastery mastery) {
         super(mastery);
     }
@@ -23,12 +23,13 @@ public class MasteryElevate extends SandmasteryManifestation{
     @Override
     public void tick(ISpiritweb data)
     {
-        if(MiscHelper.isClient(data)) performEffectClient(data);
-
         int hotkeyFlags = CompoundNBTHelper.getOrCreate(data.getCompoundTag(), "sandmastery").getInt("hotkeys");
         boolean enabledViaHotkey = false;
         if((hotkeyFlags & SandmasteryConstants.elevateFlagVal) != 0) enabledViaHotkey = true;
         if((hotkeyFlags & 1) != 0) enabledViaHotkey = true;
+
+        if(!MiscHelper.isClient(data)) MiscHelper.logToChat(data,"Serverside flags: " + hotkeyFlags);
+
         if(getMode(data) > 0 && enabledViaHotkey) performEffectServer(data);
     }
 

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryLaunch.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryLaunch.java
@@ -28,8 +28,6 @@ public class MasteryLaunch extends SandmasteryManifestation{
     @Override
     public void tick(ISpiritweb data)
     {
-        if(MiscHelper.isClient(data)) performEffectClient(data);
-
         int hotkeyFlags = CompoundNBTHelper.getOrCreate(data.getCompoundTag(), "sandmastery").getInt("hotkeys");
         boolean enabledViaHotkey = false;
         if((hotkeyFlags & SandmasteryConstants.launchFlagVal) != 0) enabledViaHotkey = true;

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryLaunch.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryLaunch.java
@@ -4,6 +4,7 @@ import leaf.cosmere.api.CosmereAPI;
 import leaf.cosmere.api.Manifestations;
 import leaf.cosmere.api.Roshar;
 import leaf.cosmere.api.Taldain;
+import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.api.math.VectorHelper;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.client.Keybindings;
@@ -12,8 +13,13 @@ import leaf.cosmere.sandmastery.client.SandmasteryKeybindings;
 import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodule;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryBlocksRegistry;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
+import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.util.thread.SidedThreadGroups;
+
 public class MasteryLaunch extends SandmasteryManifestation{
     public MasteryLaunch(Taldain.Mastery mastery) {
         super(mastery);
@@ -22,19 +28,16 @@ public class MasteryLaunch extends SandmasteryManifestation{
     @Override
     public void tick(ISpiritweb data)
     {
-        int mode = getMode(data);
-        if (mode > 0 && (MiscHelper.isActivatedAndActive(data, this) || SandmasteryKeybindings.SANDMASTERY_LAUNCH.isDown())) {
-            applyEffectTick(data);
-        }
+        if(MiscHelper.isClient(data)) performEffectClient(data);
+
+        int hotkeyFlags = CompoundNBTHelper.getOrCreate(data.getCompoundTag(), "sandmastery").getInt("hotkeys");
+        boolean enabledViaHotkey = false;
+        if((hotkeyFlags & SandmasteryConstants.launchFlagVal) != 0) enabledViaHotkey = true;
+        if((hotkeyFlags & 1) != 0) enabledViaHotkey = true;
+        if(getMode(data) > 0 && enabledViaHotkey) performEffectServer(data);
     }
 
-    @Override
-    public void applyEffectTick(ISpiritweb data)
-    {
-        performEffectServer(data);
-    }
-
-    private void performEffectServer(ISpiritweb data)
+    protected void performEffectServer(ISpiritweb data)
     {
         SpiritwebCapability playerSpiritweb = (SpiritwebCapability) data;
         SandmasterySpiritwebSubmodule submodule = (SandmasterySpiritwebSubmodule) playerSpiritweb.spiritwebSubmodules.get(Manifestations.ManifestationTypes.SANDMASTERY);

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryLaunch.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryLaunch.java
@@ -1,24 +1,15 @@
 package leaf.cosmere.sandmastery.common.manifestation;
 
-import leaf.cosmere.api.CosmereAPI;
 import leaf.cosmere.api.Manifestations;
-import leaf.cosmere.api.Roshar;
 import leaf.cosmere.api.Taldain;
-import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.api.math.VectorHelper;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
-import leaf.cosmere.client.Keybindings;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
-import leaf.cosmere.sandmastery.client.SandmasteryKeybindings;
 import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodule;
-import leaf.cosmere.sandmastery.common.registries.SandmasteryBlocksRegistry;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
 import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.fml.util.thread.SidedThreadGroups;
 
 public class MasteryLaunch extends SandmasteryManifestation{
     public MasteryLaunch(Taldain.Mastery mastery) {
@@ -28,10 +19,7 @@ public class MasteryLaunch extends SandmasteryManifestation{
     @Override
     public void tick(ISpiritweb data)
     {
-        int hotkeyFlags = CompoundNBTHelper.getOrCreate(data.getCompoundTag(), "sandmastery").getInt("hotkeys");
-        boolean enabledViaHotkey = false;
-        if((hotkeyFlags & SandmasteryConstants.launchFlagVal) != 0) enabledViaHotkey = true;
-        if((hotkeyFlags & 1) != 0) enabledViaHotkey = true;
+        boolean enabledViaHotkey = MiscHelper.enabledViaHotkey(data, SandmasteryConstants.LAUNCH_HOTKEY_FLAG);
         if(getMode(data) > 0 && enabledViaHotkey) performEffectServer(data);
     }
 

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryProjectile.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryProjectile.java
@@ -36,8 +36,6 @@ public class MasteryProjectile extends SandmasteryManifestation
 		submodule.tickProjectileCooldown();
 		if (!submodule.projectileReady()) return;
 
-		if(MiscHelper.isClient(data)) performEffectClient(data);
-
 		int hotkeyFlags = CompoundNBTHelper.getOrCreate(data.getCompoundTag(), "sandmastery").getInt("hotkeys");
 		boolean enabledViaHotkey = false;
 		if((hotkeyFlags & SandmasteryConstants.launchFlagVal) != 0) enabledViaHotkey = true;

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryProjectile.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryProjectile.java
@@ -6,13 +6,21 @@ package leaf.cosmere.sandmastery.common.manifestation;
 
 import leaf.cosmere.api.Manifestations;
 import leaf.cosmere.api.Taldain;
+import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.sandmastery.client.SandmasteryKeybindings;
 import leaf.cosmere.sandmastery.common.Sandmastery;
 import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodule;
 import leaf.cosmere.sandmastery.common.network.packets.PlayerShootSandProjectileMessage;
+import leaf.cosmere.sandmastery.common.registries.SandmasteryItems;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
+import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.util.thread.SidedThreadGroups;
 
 public class MasteryProjectile extends SandmasteryManifestation
 {
@@ -23,31 +31,36 @@ public class MasteryProjectile extends SandmasteryManifestation
 
 	@Override
 	public void tick(ISpiritweb data) {
-		int mode = getMode(data);
-		if (mode <= 0) return;
 		SpiritwebCapability playerSpiritweb = (SpiritwebCapability) data;
 		SandmasterySpiritwebSubmodule submodule = (SandmasterySpiritwebSubmodule) playerSpiritweb.spiritwebSubmodules.get(Manifestations.ManifestationTypes.SANDMASTERY);
 		submodule.tickProjectileCooldown();
 		if (!submodule.projectileReady()) return;
-		if ((MiscHelper.isActivatedAndActive(data, this) || SandmasteryKeybindings.SANDMASTERY_PROJECTILE.isDown())) {
-			applyEffectTick(data);
-		}
+
+		if(MiscHelper.isClient(data)) performEffectClient(data);
+
+		int hotkeyFlags = CompoundNBTHelper.getOrCreate(data.getCompoundTag(), "sandmastery").getInt("hotkeys");
+		boolean enabledViaHotkey = false;
+		if((hotkeyFlags & SandmasteryConstants.launchFlagVal) != 0) enabledViaHotkey = true;
+		if((hotkeyFlags & 1) != 0) enabledViaHotkey = true;
+		if(getMode(data) > 0 && enabledViaHotkey) performEffectServer(data);
 	}
 
-	@Override
-	public void applyEffectTick(ISpiritweb data)
-	{
-		performEffectServer(data);
-	}
-
-	private void performEffectServer(ISpiritweb data)
+	protected void performEffectServer(ISpiritweb data)
 	{
 		SpiritwebCapability playerSpiritweb = (SpiritwebCapability) data;
+		ServerPlayer player = (ServerPlayer) data.getLiving();
 		SandmasterySpiritwebSubmodule submodule = (SandmasterySpiritwebSubmodule) playerSpiritweb.spiritwebSubmodules.get(Manifestations.ManifestationTypes.SANDMASTERY);
 		if(!submodule.adjustHydration(-10, false)) return;
 		if(!enoughChargedSand(data)) return;
+		for (int i = 0; i < player.getInventory().getContainerSize(); i++){
+			ItemStack pouch = player.getInventory().getItem(i);
+			if (!pouch.isEmpty() && pouch.is(SandmasteryItems.SAND_POUCH_ITEM.get()))
+			{
+				SandmasteryItems.SAND_POUCH_ITEM.get().shoot(pouch, player);
 
-		Sandmastery.packetHandler().sendToServer(new PlayerShootSandProjectileMessage());
+				return;
+			}
+		}
 
 		submodule.adjustHydration(-10, true);
 		useChargedSand(data);

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryProjectile.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/MasteryProjectile.java
@@ -6,21 +6,14 @@ package leaf.cosmere.sandmastery.common.manifestation;
 
 import leaf.cosmere.api.Manifestations;
 import leaf.cosmere.api.Taldain;
-import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
-import leaf.cosmere.sandmastery.client.SandmasteryKeybindings;
-import leaf.cosmere.sandmastery.common.Sandmastery;
 import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodule;
-import leaf.cosmere.sandmastery.common.network.packets.PlayerShootSandProjectileMessage;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryItems;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
 import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.fml.util.thread.SidedThreadGroups;
 
 public class MasteryProjectile extends SandmasteryManifestation
 {
@@ -36,10 +29,7 @@ public class MasteryProjectile extends SandmasteryManifestation
 		submodule.tickProjectileCooldown();
 		if (!submodule.projectileReady()) return;
 
-		int hotkeyFlags = CompoundNBTHelper.getOrCreate(data.getCompoundTag(), "sandmastery").getInt("hotkeys");
-		boolean enabledViaHotkey = false;
-		if((hotkeyFlags & SandmasteryConstants.launchFlagVal) != 0) enabledViaHotkey = true;
-		if((hotkeyFlags & 1) != 0) enabledViaHotkey = true;
+		boolean enabledViaHotkey = MiscHelper.enabledViaHotkey(data, SandmasteryConstants.PROJECTILE_HOTKEY_FLAG);
 		if(getMode(data) > 0 && enabledViaHotkey) performEffectServer(data);
 	}
 

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/SandmasteryManifestation.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/SandmasteryManifestation.java
@@ -12,14 +12,22 @@ import leaf.cosmere.api.manifestation.Manifestation;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.common.charge.ItemChargeHelper;
+import leaf.cosmere.sandmastery.client.SandmasteryKeybindings;
+import leaf.cosmere.sandmastery.common.Sandmastery;
 import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodule;
 import leaf.cosmere.sandmastery.common.items.SandPouchItem;
+import leaf.cosmere.sandmastery.common.network.packets.SyncMasteryBindsMessage;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryAttributes;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryItems;
+import leaf.cosmere.sandmastery.common.utils.MiscHelper;
+import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -139,4 +147,16 @@ public class SandmasteryManifestation extends Manifestation
 		return SandmasteryAttributes.RIBBONS.getAttribute();
 	}
 
+	protected void performEffectClient(ISpiritweb data)
+	{
+		CompoundTag nbt = new CompoundTag();
+		int flags = 0;
+		flags =
+				(MiscHelper.isActivatedAndActive(data, this) ? 1 : 0) +
+				(SandmasteryKeybindings.SANDMASTERY_ELEVATE.isDown() ? SandmasteryConstants.elevateFlagVal : 0) +
+				(SandmasteryKeybindings.SANDMASTERY_LAUNCH.isDown() ? SandmasteryConstants.launchFlagVal : 0) +
+				(SandmasteryKeybindings.SANDMASTERY_PROJECTILE.isDown() ? SandmasteryConstants.projectileFlagVal : 0);
+		nbt.putInt("hotkeys", flags);
+		Sandmastery.packetHandler().sendToServer(new SyncMasteryBindsMessage(nbt));
+	}
 }

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/SandmasteryManifestation.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/SandmasteryManifestation.java
@@ -186,9 +186,9 @@ public class SandmasteryManifestation extends Manifestation
 	protected void performEffectClient(ISpiritweb data)
 	{
 		int currentFlags = (MiscHelper.isActivatedAndActive(data, this) ? 1 : 0) +
-				(SandmasteryKeybindings.SANDMASTERY_ELEVATE.isDown() ? SandmasteryConstants.elevateFlagVal : 0) +
-				(SandmasteryKeybindings.SANDMASTERY_LAUNCH.isDown() ? SandmasteryConstants.launchFlagVal : 0) +
-				(SandmasteryKeybindings.SANDMASTERY_PROJECTILE.isDown() ? SandmasteryConstants.projectileFlagVal : 0);
+				(SandmasteryKeybindings.SANDMASTERY_ELEVATE.isDown() ? SandmasteryConstants.ELEVATE_HOTKEY_FLAG : 0) +
+				(SandmasteryKeybindings.SANDMASTERY_LAUNCH.isDown() ? SandmasteryConstants.LAUNCH_HOTKEY_FLAG : 0) +
+				(SandmasteryKeybindings.SANDMASTERY_PROJECTILE.isDown() ? SandmasteryConstants.PROJECTILE_HOTKEY_FLAG : 0);
 
 		final CompoundTag dataTag = data.getCompoundTag();
 		final CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(dataTag, "sandmastery");

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/SandmasteryManifestation.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/SandmasteryManifestation.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 8 - 10 - 2022 ~ Leaf
+ * File updated ~ 9 - 2 - 2023 ~ Leaf
  */
 
 package leaf.cosmere.sandmastery.common.manifestation;
@@ -7,6 +7,7 @@ package leaf.cosmere.sandmastery.common.manifestation;
 import leaf.cosmere.api.Constants;
 import leaf.cosmere.api.Manifestations;
 import leaf.cosmere.api.Taldain;
+import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.api.helpers.StackNBTHelper;
 import leaf.cosmere.api.manifestation.Manifestation;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
@@ -18,7 +19,6 @@ import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodul
 import leaf.cosmere.sandmastery.common.items.SandPouchItem;
 import leaf.cosmere.sandmastery.common.network.packets.SyncMasteryBindsMessage;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryAttributes;
-import leaf.cosmere.sandmastery.common.registries.SandmasteryItems;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
 import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
 import net.minecraft.nbt.CompoundTag;
@@ -26,9 +26,6 @@ import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import org.stringtemplate.v4.misc.Misc;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -44,8 +41,12 @@ public class SandmasteryManifestation extends Manifestation
 	}
 
 	@Override
-	public void tick(ISpiritweb data) {
-		if(MiscHelper.isClient(data)) performEffectClient(data);
+	public void tick(ISpiritweb data)
+	{
+		if (MiscHelper.isClient(data))
+		{
+			performEffectClient(data);
+		}
 	}
 
 	@Override
@@ -66,62 +67,87 @@ public class SandmasteryManifestation extends Manifestation
 	}
 
 	@Override
-	public int modeMin(ISpiritweb data) {
+	public int modeMin(ISpiritweb data)
+	{
 		return 0;
 	}
 
 	@Override
-	public int modeMax(ISpiritweb data) {
+	public int modeMax(ISpiritweb data)
+	{
 		return (int) data.getSelectedManifestation().getStrength(data, false);
 	}
 
 	@Override
-	public void onModeChange(ISpiritweb data, int lastMode) {
+	public void onModeChange(ISpiritweb data, int lastMode)
+	{
 		SpiritwebCapability playerSpiritweb = (SpiritwebCapability) data;
 		SandmasterySpiritwebSubmodule submodule = (SandmasterySpiritwebSubmodule) playerSpiritweb.spiritwebSubmodules.get(Manifestations.ManifestationTypes.SANDMASTERY);
-		if(getMode(data) > lastMode) {
+		if (getMode(data) > lastMode)
+		{
 			submodule.useRibbon(data, this);
-		} else if(getMode(data) < lastMode) {
+		}
+		else if (getMode(data) < lastMode)
+		{
 			submodule.releaseRibbon(data, this);
 		}
 	}
 
-	protected boolean enoughChargedSand(ISpiritweb data) {
-		if(data.getLiving() instanceof Player player) {
+	protected boolean enoughChargedSand(ISpiritweb data)
+	{
+		if (data.getLiving() instanceof Player player)
+		{
 			List<ItemStack> allPouches = getSandPouches(player);
 			int required = getCost(data);
 
-			if (allPouches.isEmpty()) return false;
+			if (allPouches.isEmpty())
+			{
+				return false;
+			}
 
 			int count = 0;
-			for(ItemStack stack : allPouches) {
+			for (ItemStack stack : allPouches)
+			{
 				count += StackNBTHelper.getInt(stack, Constants.NBT.CHARGE_LEVEL, 0);
-				if(count > required) return true;
+				if (count > required)
+				{
+					return true;
+				}
 			}
 		}
 		return false;
 	}
 
-	public void useChargedSand(ISpiritweb data) {
-		if(data.getLiving() instanceof Player player) {
+	public void useChargedSand(ISpiritweb data)
+	{
+		if (data.getLiving() instanceof Player player)
+		{
 			List<ItemStack> allPouches = getSandPouches(player);
 
 			int changeLeft = getCost(data);
-			for (ItemStack stack : allPouches) {
+			for (ItemStack stack : allPouches)
+			{
 				int startingCharge = StackNBTHelper.getInt(stack, Constants.NBT.CHARGE_LEVEL, 0);
 				int amountLeft = (startingCharge - changeLeft);
-				if(amountLeft >= 0)
+				if (amountLeft >= 0)
+				{
 					StackNBTHelper.setInt(stack, Constants.NBT.CHARGE_LEVEL, amountLeft);
-				else {
+				}
+				else
+				{
 					StackNBTHelper.setInt(stack, Constants.NBT.CHARGE_LEVEL, 0);
 					changeLeft += amountLeft;
 				}
-				if(changeLeft <= 0) break;
+				if (changeLeft <= 0)
+				{
+					break;
+				}
 			}
 		}
 	}
 
-	protected List<ItemStack> getSandPouches(Player player) {
+	protected List<ItemStack> getSandPouches(Player player)
+	{
 		List<ItemStack> curios = ItemChargeHelper.getChargeCurios(player);
 		List<ItemStack> items = ItemChargeHelper.getChargeItems(player);
 
@@ -143,26 +169,35 @@ public class SandmasteryManifestation extends Manifestation
 	{
 		return obj ->
 		{
-			if (obj.getItem() instanceof SandPouchItem) return false;
+			if (obj.getItem() instanceof SandPouchItem)
+			{
+				return false;
+			}
 			return true;
 		};
 	}
 
 	@Override
-	public Attribute getAttribute() {
+	public Attribute getAttribute()
+	{
 		return SandmasteryAttributes.RIBBONS.getAttribute();
 	}
 
 	protected void performEffectClient(ISpiritweb data)
 	{
-		CompoundTag nbt = new CompoundTag();
-		int flags = 0;
-		flags =
-				(MiscHelper.isActivatedAndActive(data, this) ? 1 : 0) +
+		int currentFlags = (MiscHelper.isActivatedAndActive(data, this) ? 1 : 0) +
 				(SandmasteryKeybindings.SANDMASTERY_ELEVATE.isDown() ? SandmasteryConstants.elevateFlagVal : 0) +
 				(SandmasteryKeybindings.SANDMASTERY_LAUNCH.isDown() ? SandmasteryConstants.launchFlagVal : 0) +
 				(SandmasteryKeybindings.SANDMASTERY_PROJECTILE.isDown() ? SandmasteryConstants.projectileFlagVal : 0);
-		nbt.putInt("hotkeys", flags);
-		Sandmastery.packetHandler().sendToServer(new SyncMasteryBindsMessage(nbt));
+
+		final CompoundTag dataTag = data.getCompoundTag();
+		final CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(dataTag, "sandmastery");
+		int savedFlags = sandmasteryTag.getInt("hotkeys");
+
+		if (savedFlags != currentFlags)
+		{
+			sandmasteryTag.putInt("hotkeys", currentFlags);
+			Sandmastery.packetHandler().sendToServer(new SyncMasteryBindsMessage(currentFlags));
+		}
 	}
 }

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/SandmasteryManifestation.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/manifestation/SandmasteryManifestation.java
@@ -28,6 +28,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import org.stringtemplate.v4.misc.Misc;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -40,6 +41,11 @@ public class SandmasteryManifestation extends Manifestation
 	{
 		super(Manifestations.ManifestationTypes.SANDMASTERY);
 		this.mastery = mastery;
+	}
+
+	@Override
+	public void tick(ISpiritweb data) {
+		if(MiscHelper.isClient(data)) performEffectClient(data);
 	}
 
 	@Override

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/SandmasteryPacketHandler.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/SandmasteryPacketHandler.java
@@ -8,6 +8,7 @@ import leaf.cosmere.sandmastery.common.network.packets.PlayerShootSandProjectile
 import leaf.cosmere.common.Cosmere;
 import leaf.cosmere.common.network.BasePacketHandler;
 import leaf.cosmere.sandmastery.common.Sandmastery;
+import leaf.cosmere.sandmastery.common.network.packets.SyncMasteryBindsMessage;
 import net.minecraftforge.network.simple.SimpleChannel;
 
 public class SandmasteryPacketHandler extends BasePacketHandler
@@ -24,6 +25,7 @@ public class SandmasteryPacketHandler extends BasePacketHandler
 	public void initialize()
 	{
 		registerClientToServer(PlayerShootSandProjectileMessage.class, PlayerShootSandProjectileMessage::decode);
+		registerClientToServer(SyncMasteryBindsMessage.class, SyncMasteryBindsMessage::decode);
 
 	}
 

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/packets/PlayerShootSandProjectileMessage.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/packets/PlayerShootSandProjectileMessage.java
@@ -36,19 +36,7 @@ public class PlayerShootSandProjectileMessage implements ICosmerePacket
 	{
 		ServerPlayer player = context.getSender();
 		MinecraftServer server = player.getServer();
-		server.submitAsync(() -> SpiritwebCapability.get(player).ifPresent((cap) ->
-		{
-			for (int i = 0; i < player.getInventory().getContainerSize(); i++)
-			{
-				ItemStack pouch = player.getInventory().getItem(i);
-				if (!pouch.isEmpty() && pouch.is(SandmasteryItems.SAND_POUCH_ITEM.get()))
-				{
-					SandmasteryItems.SAND_POUCH_ITEM.get().shoot(pouch, player);
 
-					return;
-				}
-			}
-		}));
 	}
 
 }

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/packets/SyncMasteryBindsMessage.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/packets/SyncMasteryBindsMessage.java
@@ -7,7 +7,9 @@ package leaf.cosmere.sandmastery.common.network.packets;
 import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.common.network.ICosmerePacket;
+import leaf.cosmere.sandmastery.common.Sandmastery;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
+import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.MinecraftServer;
@@ -44,11 +46,9 @@ public class SyncMasteryBindsMessage implements ICosmerePacket
 			SpiritwebCapability spiritweb = (SpiritwebCapability) cap;
 
 			final CompoundTag spiritwebCompoundTag = spiritweb.getCompoundTag();
-			CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(spiritwebCompoundTag, "sandmastery");
+			CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(spiritwebCompoundTag, Sandmastery.MODID);
 
-			sandmasteryTag.putInt("hotkeys", this.flags);
-
-			MiscHelper.logToChat(cap, "Packet flags: " + flags);
+			sandmasteryTag.putInt(SandmasteryConstants.HOTKEY_TAG, this.flags);
 
 		}));
 	}

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/packets/SyncMasteryBindsMessage.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/packets/SyncMasteryBindsMessage.java
@@ -1,44 +1,37 @@
 /*
- * File updated ~ 24 - 4 - 2021 ~ Leaf
+ * File updated ~ 9 - 2 - 2023 ~ Leaf
  */
 
 package leaf.cosmere.sandmastery.common.network.packets;
 
-import leaf.cosmere.api.CosmereAPI;
-import leaf.cosmere.api.helpers.CodecHelper;
 import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.common.network.ICosmerePacket;
 import leaf.cosmere.sandmastery.common.utils.MiscHelper;
-import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
-import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtOps;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
-
 public class SyncMasteryBindsMessage implements ICosmerePacket
 {
-	public CompoundTag data;
+	public int flags;
 
-	public SyncMasteryBindsMessage(CompoundTag data)
+	public SyncMasteryBindsMessage(int flags)
 	{
-		this.data = data;
+		this.flags = flags;
 	}
 
 	@Override
 	public void encode(FriendlyByteBuf buf)
 	{
-		buf.writeNbt(data);
+		buf.writeInt(flags);
 	}
 
 	public static SyncMasteryBindsMessage decode(FriendlyByteBuf buf)
 	{
-		return new SyncMasteryBindsMessage(buf.readNbt());
+		return new SyncMasteryBindsMessage(buf.readInt());
 	}
 
 	@Override
@@ -49,10 +42,13 @@ public class SyncMasteryBindsMessage implements ICosmerePacket
 		server.submitAsync(() -> SpiritwebCapability.get(sender).ifPresent((cap) ->
 		{
 			SpiritwebCapability spiritweb = (SpiritwebCapability) cap;
-			CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(spiritweb.getCompoundTag(), "sandmastery");
-			sandmasteryTag.putInt("hotkey_flags", this.data.getInt("hotkeys"));
 
-			MiscHelper.logToChat(cap,"Packet flags: " + this.data.getInt("hotkeys"));
+			final CompoundTag spiritwebCompoundTag = spiritweb.getCompoundTag();
+			CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(spiritwebCompoundTag, "sandmastery");
+
+			sandmasteryTag.putInt("hotkeys", this.flags);
+
+			MiscHelper.logToChat(cap, "Packet flags: " + flags);
 
 		}));
 	}

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/packets/SyncMasteryBindsMessage.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/packets/SyncMasteryBindsMessage.java
@@ -1,0 +1,55 @@
+/*
+ * File updated ~ 24 - 4 - 2021 ~ Leaf
+ */
+
+package leaf.cosmere.sandmastery.common.network.packets;
+
+import leaf.cosmere.api.CosmereAPI;
+import leaf.cosmere.api.helpers.CodecHelper;
+import leaf.cosmere.api.helpers.CompoundNBTHelper;
+import leaf.cosmere.common.cap.entity.SpiritwebCapability;
+import leaf.cosmere.common.network.ICosmerePacket;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.List;
+
+public class SyncMasteryBindsMessage implements ICosmerePacket
+{
+	public CompoundTag data;
+
+	public SyncMasteryBindsMessage(CompoundTag data)
+	{
+		this.data = data;
+	}
+
+	@Override
+	public void encode(FriendlyByteBuf buf)
+	{
+		buf.writeNbt(data);
+	}
+
+	public static SyncMasteryBindsMessage decode(FriendlyByteBuf buf)
+	{
+		return new SyncMasteryBindsMessage(buf.readNbt());
+	}
+
+	@Override
+	public void handle(NetworkEvent.Context context)
+	{
+		ServerPlayer sender = context.getSender();
+		MinecraftServer server = sender.getServer();
+		server.submitAsync(() -> SpiritwebCapability.get(sender).ifPresent((cap) ->
+		{
+			SpiritwebCapability spiritweb = (SpiritwebCapability) cap;
+			CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(spiritweb.getCompoundTag(), "sandmastery");
+			sandmasteryTag.putInt("hotkey_flags", this.data.getInt("hotkeys"));
+		}));
+	}
+
+}

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/packets/SyncMasteryBindsMessage.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/network/packets/SyncMasteryBindsMessage.java
@@ -9,6 +9,8 @@ import leaf.cosmere.api.helpers.CodecHelper;
 import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.common.network.ICosmerePacket;
+import leaf.cosmere.sandmastery.common.utils.MiscHelper;
+import leaf.cosmere.sandmastery.common.utils.SandmasteryConstants;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
@@ -49,6 +51,9 @@ public class SyncMasteryBindsMessage implements ICosmerePacket
 			SpiritwebCapability spiritweb = (SpiritwebCapability) cap;
 			CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(spiritweb.getCompoundTag(), "sandmastery");
 			sandmasteryTag.putInt("hotkey_flags", this.data.getInt("hotkeys"));
+
+			MiscHelper.logToChat(cap,"Packet flags: " + this.data.getInt("hotkeys"));
+
 		}));
 	}
 

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/utils/MiscHelper.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/utils/MiscHelper.java
@@ -24,6 +24,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import net.minecraftforge.fml.util.thread.SidedThreadGroups;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.List;
@@ -126,5 +127,11 @@ public class MiscHelper {
         if (data.getLiving() instanceof Player player) {
             player.sendSystemMessage(Component.literal(msg));
         }
+    }
+
+    public static boolean isClient(ISpiritweb data) {
+        boolean clientSide = data.getLiving().level.isClientSide();
+        System.out.println("Clientside: " + clientSide); // Always says false for some reason *scream*
+        return clientSide;
     }
 }

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/utils/MiscHelper.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/utils/MiscHelper.java
@@ -1,16 +1,19 @@
 package leaf.cosmere.sandmastery.common.utils;
 
 import leaf.cosmere.api.*;
+import leaf.cosmere.api.helpers.CompoundNBTHelper;
 import leaf.cosmere.api.helpers.StackNBTHelper;
 import leaf.cosmere.api.manifestation.Manifestation;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.client.Keybindings;
 import leaf.cosmere.common.Cosmere;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
+import leaf.cosmere.sandmastery.common.Sandmastery;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryBlocksRegistry;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryDimensions;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryItems;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
@@ -132,5 +135,25 @@ public class MiscHelper {
     public static boolean isClient(ISpiritweb data) {
         boolean clientSide = data.getLiving().level.isClientSide;
         return clientSide;
+    }
+
+    public static int getHotkeyFlags(ISpiritweb data) {
+        final CompoundTag dataTag = data.getCompoundTag();
+        final CompoundTag sandmasteryTag = CompoundNBTHelper.getOrCreate(dataTag, Sandmastery.MODID);
+        return sandmasteryTag.getInt(SandmasteryConstants.HOTKEY_TAG);
+    }
+
+    public static boolean enabledViaHotkey(ISpiritweb data, int requiredFlag) {
+        int hotkeyFlags = getHotkeyFlags(data);
+        boolean enabledViaHotkey = false;
+        if ((hotkeyFlags & requiredFlag) != 0)
+        {
+            enabledViaHotkey = true;
+        }
+        if ((hotkeyFlags & 1) != 0)
+        {
+            enabledViaHotkey = true;
+        }
+        return enabledViaHotkey;
     }
 }

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/utils/MiscHelper.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/utils/MiscHelper.java
@@ -130,8 +130,7 @@ public class MiscHelper {
     }
 
     public static boolean isClient(ISpiritweb data) {
-        boolean clientSide = data.getLiving().level.isClientSide();
-        System.out.println("Clientside: " + clientSide); // Always says false for some reason *scream*
+        boolean clientSide = data.getLiving().level.isClientSide;
         return clientSide;
     }
 }

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/utils/SandmasteryConstants.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/utils/SandmasteryConstants.java
@@ -4,8 +4,9 @@ public class SandmasteryConstants {
     public static final String KEY_SANDMASTERY_LAUNCH = "key.cosmere.sandmastery.launch";
     public static final String KEY_SANDMASTERY_ELEVATE = "key.cosmere.sandmastery.elevate";
     public static final String KEY_SANDMASTERY_PROJECTILE = "key.cosmere.sandmastery.projectile";
-    public static final int chargePerLayerOfSand = 100;
-    public static final int elevateFlagVal = 2;
-    public static final int launchFlagVal = 4;
-    public static final int projectileFlagVal = 8;
+    public static final String HOTKEY_TAG = "hotkeys";
+    public static final int CHARGE_PER_SAND_LAYER = 100;
+    public static final int ELEVATE_HOTKEY_FLAG = 2;
+    public static final int LAUNCH_HOTKEY_FLAG = 4;
+    public static final int PROJECTILE_HOTKEY_FLAG = 8;
 }

--- a/src/sandmastery/Java/leaf/cosmere/sandmastery/common/utils/SandmasteryConstants.java
+++ b/src/sandmastery/Java/leaf/cosmere/sandmastery/common/utils/SandmasteryConstants.java
@@ -5,4 +5,7 @@ public class SandmasteryConstants {
     public static final String KEY_SANDMASTERY_ELEVATE = "key.cosmere.sandmastery.elevate";
     public static final String KEY_SANDMASTERY_PROJECTILE = "key.cosmere.sandmastery.projectile";
     public static final int chargePerLayerOfSand = 100;
+    public static final int elevateFlagVal = 2;
+    public static final int launchFlagVal = 4;
+    public static final int projectileFlagVal = 8;
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
Fixed bugs:
Server tried to run client code
Server doesn't properly transfer attributes between a dead player and a respawned player causing some powers to be lost on death