### PR TITLE
One more bugfix

### DIFF
--- a/src/allomancy/java/leaf/cosmere/allomancy/client/metalScanning/IronSteelLinesThread.java
+++ b/src/allomancy/java/leaf/cosmere/allomancy/client/metalScanning/IronSteelLinesThread.java
@@ -268,6 +268,16 @@ public class IronSteelLinesThread implements Runnable {
             catch (Exception e)
             {
                 CosmereAPI.logger.info("Issue with lines thread");
+                Player player = Minecraft.getInstance().player;
+                Level level = Minecraft.getInstance().level;
+
+                // if this check doesn't happen, the thread gets stuck in a loop when exiting worlds
+                if (player == null || level == null)
+                {
+                    stop();
+                    break;
+                }
+
                 e.printStackTrace();
             }
         }


### PR DESCRIPTION
## Changes proposed in this pull request:
I introduced a bug when I fixed the lines thread issue, so here's the fix. 
The bug caused the thread not to exit properly when exiting a world, which isn't all that bad. But it does cause _extreme_ log bloat.