### PR TITLE
[Feruchemy] Gold TLC

### DIFF
--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
@@ -101,7 +101,4 @@ public class GoldTapEffect extends FeruchemyEffectBase
 			}
 		}
 	}
-
-
-
 }

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
@@ -103,7 +103,7 @@ public class GoldTapEffect extends FeruchemyEffectBase
 			{
 				// the cost of not dying should be all the extra damage * 50
 				int amount = (int) (event.getAmount() - player.getHealth()) * 50;
-				final ItemStack metalmind = MetalmindChargeHelper.adjustMetalmindChargeExact(player, Metals.MetalType.GOLD, amount, true, true);
+				final ItemStack metalmind = MetalmindChargeHelper.adjustMetalmindChargeExact(player, Metals.MetalType.GOLD, -amount, true, true);
 
 				if (!metalmind.isEmpty())
 				{

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 8 - 11 - 2023 ~ Leaf
+ * File updated ~ 14 - 02 - 2024 ~ Gerbagel
  */
 
 package leaf.cosmere.feruchemy.common.effects.tap;
@@ -19,9 +19,6 @@ import net.minecraftforge.event.entity.living.LivingHurtEvent;
 
 public class GoldTapEffect extends FeruchemyEffectBase
 {
-	private static final int MIN_TAP_FOR_ABSORPTION = 5;
-	private float absorbtionLastHealTick = 0F;
-	private boolean isHealInit = false;
 
 	public GoldTapEffect(Metals.MetalType type)
 	{
@@ -47,20 +44,8 @@ public class GoldTapEffect extends FeruchemyEffectBase
 		if (isHealTick)
 		{
 			final int amountToHeal = 1;
-			if (living.getHealth() >= living.getMaxHealth() && i >= MIN_TAP_FOR_ABSORPTION)  // if health is at max and tapping 7+
-			{
-				float maxAbsorption = i - MIN_TAP_FOR_ABSORPTION + 1F;
-				float absorptionAmount = living.getAbsorptionAmount();
 
-				if (absorptionAmount < maxAbsorption)
-				{
-					living.setAbsorptionAmount(absorptionAmount + 0.5F);
-				}
-			}
-			else
-			{
-				living.heal(amountToHeal);
-			}
+			living.heal(amountToHeal);
 		}
 
 		if (living.tickCount % (getActiveTick() + getTickOffset()) == 0)
@@ -97,6 +82,8 @@ public class GoldTapEffect extends FeruchemyEffectBase
 		return true;
 	}
 
+
+
 	public static void onLivingHurtEvent(LivingHurtEvent event)
 	{
 		if (event.isCanceled())
@@ -114,5 +101,7 @@ public class GoldTapEffect extends FeruchemyEffectBase
 			}
 		}
 	}
+
+
 
 }

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
@@ -9,8 +9,10 @@ import leaf.cosmere.api.helpers.EntityHelper;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.common.registry.AttributesRegistry;
 import leaf.cosmere.feruchemy.common.effects.FeruchemyEffectBase;
+import leaf.cosmere.feruchemy.common.manifestation.FeruchemyGold;
 import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 
@@ -29,37 +31,53 @@ public class GoldTapEffect extends FeruchemyEffectBase
 	@Override
 	public void applyEffectTick(ISpiritweb data, double strength)
 	{
-		var living = data.getLiving();
-
+		final LivingEntity living = data.getLiving();
 		final int i = (int) (strength);
-		if (living.getHealth() < living.getMaxHealth())
+		boolean isHealTick;
+
+		// at min tap (1) should be active every 10 seconds     // 10 seconds is 200 ticks
+		int healActiveTick = FeruchemyGold.getHealActiveTick(i);
+		healActiveTick = Math.max(1, healActiveTick);   // can't tick more often than every tick
+		isHealTick = living.tickCount % healActiveTick == 0;
+
+		if (isHealTick)
 		{
-			living.heal(i);
+			final int amountToHeal = 1;
+			living.heal(amountToHeal);
 		}
 
-		//todo move to config
-		final int timeToReduceByInTicks = i * 40;
-		final int ticksNeededLeftToReduce = 5;
-
-		//remove harmful effects over time
-		for (MobEffectInstance activeEffect : living.getActiveEffects())
+		if (living.tickCount % (getActiveTick() + getTickOffset()) == 0)
 		{
-			if (!activeEffect.getEffect().isBeneficial() && activeEffect.getDuration() > ticksNeededLeftToReduce)
+			//todo move to config
+			final int timeToReduceByInTicks = i * 40;
+			final int ticksNeededLeftToReduce = 5;
+
+			//remove harmful effects over time
+			for (MobEffectInstance activeEffect : living.getActiveEffects())
 			{
-				//never reduce down below 5 ticks
-				final double clamped = Math.max(ticksNeededLeftToReduce, activeEffect.getDuration() - timeToReduceByInTicks);
-				final int duration = Mth.floor(clamped);
-				MobEffectInstance newInstance = new MobEffectInstance(
-						activeEffect.getEffect(),
-						duration,
-						activeEffect.getAmplifier(),
-						activeEffect.isAmbient(),
-						activeEffect.isVisible(),
-						activeEffect.showIcon());
-				living.removeEffectNoUpdate(activeEffect.getEffect());
-				living.addEffect(newInstance);
+				if (!activeEffect.getEffect().isBeneficial() && activeEffect.getDuration() > ticksNeededLeftToReduce)
+				{
+					//never reduce down below 5 ticks
+					final double clamped = Math.max(ticksNeededLeftToReduce, activeEffect.getDuration() - timeToReduceByInTicks);
+					final int duration = Mth.floor(clamped);
+					MobEffectInstance newInstance = new MobEffectInstance(
+							activeEffect.getEffect(),
+							duration,
+							activeEffect.getAmplifier(),
+							activeEffect.isAmbient(),
+							activeEffect.isVisible(),
+							activeEffect.showIcon());
+					living.removeEffectNoUpdate(activeEffect.getEffect());
+					living.addEffect(newInstance);
+				}
 			}
 		}
+	}
+
+	@Override
+	protected boolean isActiveTick(ISpiritweb data)
+	{
+		return true;
 	}
 
 	public static void onLivingHurtEvent(LivingHurtEvent event)

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
@@ -19,6 +19,10 @@ import net.minecraftforge.event.entity.living.LivingHurtEvent;
 
 public class GoldTapEffect extends FeruchemyEffectBase
 {
+	private static final int MIN_TAP_FOR_ABSORPTION = 5;
+	private float absorbtionLastHealTick = 0F;
+	private boolean isHealInit = false;
+
 	public GoldTapEffect(Metals.MetalType type)
 	{
 		super(type);
@@ -43,7 +47,20 @@ public class GoldTapEffect extends FeruchemyEffectBase
 		if (isHealTick)
 		{
 			final int amountToHeal = 1;
-			living.heal(amountToHeal);
+			if (living.getHealth() >= living.getMaxHealth() && i >= MIN_TAP_FOR_ABSORPTION)  // if health is at max and tapping 7+
+			{
+				float maxAbsorption = i - MIN_TAP_FOR_ABSORPTION + 1F;
+				float absorptionAmount = living.getAbsorptionAmount();
+
+				if (absorptionAmount < maxAbsorption)
+				{
+					living.setAbsorptionAmount(absorptionAmount + 0.5F);
+				}
+			}
+			else
+			{
+				living.heal(amountToHeal);
+			}
 		}
 
 		if (living.tickCount % (getActiveTick() + getTickOffset()) == 0)

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/effects/tap/GoldTapEffect.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 14 - 02 - 2024 ~ Gerbagel
+ * File updated ~ 21 - 02 - 2024 ~ Gerbagel
  */
 
 package leaf.cosmere.feruchemy.common.effects.tap;
@@ -7,6 +7,7 @@ package leaf.cosmere.feruchemy.common.effects.tap;
 import leaf.cosmere.api.Metals;
 import leaf.cosmere.api.helpers.EntityHelper;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
+import leaf.cosmere.common.charge.MetalmindChargeHelper;
 import leaf.cosmere.common.registry.AttributesRegistry;
 import leaf.cosmere.feruchemy.common.effects.FeruchemyEffectBase;
 import leaf.cosmere.feruchemy.common.manifestation.FeruchemyGold;
@@ -14,6 +15,8 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 
 
@@ -94,10 +97,18 @@ public class GoldTapEffect extends FeruchemyEffectBase
 		if (event.getAmount() > event.getEntity().getHealth())
 		{
 			int strength = (int) EntityHelper.getAttributeValue(event.getEntity(), AttributesRegistry.HEALING_STRENGTH.getAttribute(), 0);
+
 			//take less damage when tapping
-			if (strength > 6)
+			if (strength > 6 && event.getEntity() instanceof Player player)
 			{
-				event.setAmount(event.getEntity().getHealth() - 1);
+				// the cost of not dying should be all the extra damage * 50
+				int amount = (int) (event.getAmount() - player.getHealth()) * 50;
+				final ItemStack metalmind = MetalmindChargeHelper.adjustMetalmindChargeExact(player, Metals.MetalType.GOLD, amount, true, true);
+
+				if (!metalmind.isEmpty())
+				{
+					event.setAmount((float) Math.floor(player.getHealth() - 1));
+				}
 			}
 		}
 	}

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyGold.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyGold.java
@@ -8,6 +8,12 @@ import leaf.cosmere.api.Metals;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.feruchemy.common.config.FeruchemyConfigs;
 
+// Todo for TLC:
+//      - rebalance death resistance
+//      - 1 tap should be half a heart every 10-20 seconds
+//      - max tap (32?) will be half a heart every tick // VERY EXPENSIVE, should drain faster than max compounding
+//      - keep tapping at max health (sorry all y'all bloodmakers) buff max health instead at a high enough tap rate (3+?). Half a heart per tap level above?
+
 public class FeruchemyGold extends FeruchemyManifestation
 {
 	public FeruchemyGold(Metals.MetalType metalType)

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyGold.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyGold.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 19er - 02 - 2024 ~ Gerbagel
+ * File updated ~ 21 - 02 - 2024 ~ Gerbagel
  */
 
 package leaf.cosmere.feruchemy.common.manifestation;
@@ -12,10 +12,6 @@ import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.feruchemy.common.config.FeruchemyConfigs;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
-
-// Todo for TLC:
-//      - rebalance death resistance
-//      - max tap (32?) will be half a heart every tick // VERY EXPENSIVE, should drain faster than max compounding
 
 public class FeruchemyGold extends FeruchemyManifestation
 {

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyGold.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyGold.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 14 - 02 - 2024 ~ Gerbagel
+ * File updated ~ 19er - 02 - 2024 ~ Gerbagel
  */
 
 package leaf.cosmere.feruchemy.common.manifestation;
@@ -38,7 +38,7 @@ public class FeruchemyGold extends FeruchemyManifestation
 	public boolean tick(ISpiritweb data)
 	{
 		//don't heal more than needed.
-		if (!isActiveTick(data))
+		if (!isHealActiveTick(data))
 		{
 			return false;
 		}
@@ -76,6 +76,12 @@ public class FeruchemyGold extends FeruchemyManifestation
 
 		// this updates health immediately rather than waiting for a health update
 		data.getLiving().setHealth(data.getLiving().getHealth());
+	}
+
+	public boolean isHealActiveTick(ISpiritweb data)
+	{
+		int healTick = Math.max(1, getHealActiveTick(-getMode(data)));
+		return data.getLiving().tickCount % healTick == 0;
 	}
 
 	public static int getHealActiveTick(int strength)

--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyGold.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyGold.java
@@ -7,7 +7,6 @@ package leaf.cosmere.feruchemy.common.manifestation;
 import leaf.cosmere.api.Metals;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
 import leaf.cosmere.feruchemy.common.config.FeruchemyConfigs;
-import net.minecraft.world.entity.LivingEntity;
 
 public class FeruchemyGold extends FeruchemyManifestation
 {
@@ -28,16 +27,8 @@ public class FeruchemyGold extends FeruchemyManifestation
 	@Override
 	public boolean tick(ISpiritweb data)
 	{
-		//don't check every tick.
-		LivingEntity livingEntity = data.getLiving();
-
 		//don't heal more than needed.
 		if (!isActiveTick(data))
-		{
-			return false;
-		}
-
-		if (isTapping(data) && livingEntity.getHealth() >= livingEntity.getMaxHealth())
 		{
 			return false;
 		}
@@ -55,5 +46,10 @@ public class FeruchemyGold extends FeruchemyManifestation
 			return isTapping(data);
 		}
 		return false;
+	}
+
+	public static int getHealActiveTick(int strength)
+	{
+		return (int) Math.floor(200*Math.pow(strength, -1.5D));
 	}
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Gold now heals faster rather than more hearts, half a heart per "heal tick"
- Cost is higher
- Gold no longer stops tapping at max health, and instead grants extra hearts above a certain tap level
- Death resistance now has a cost, and leaves the player with 1 health remaining after lethal damage