### PR TITLE
Feature/patchouli changes

### DIFF
--- a/src/datagen/allomancy/java/leaf/cosmere/allomancy/patchouli/PatchouliAllomancyCategory.java
+++ b/src/datagen/allomancy/java/leaf/cosmere/allomancy/patchouli/PatchouliAllomancyCategory.java
@@ -9,6 +9,7 @@ import leaf.cosmere.allomancy.common.registries.AllomancyManifestations;
 import leaf.cosmere.api.Constants;
 import leaf.cosmere.api.Metals;
 import leaf.cosmere.api.text.StringHelper;
+import leaf.cosmere.client.Keybindings;
 import leaf.cosmere.common.registration.impl.ManifestationRegistryObject;
 import leaf.cosmere.patchouli.data.BookStuff;
 import leaf.cosmere.patchouli.data.PatchouliTextFormat;
@@ -105,11 +106,15 @@ public class PatchouliAllomancyCategory
 				case IRON:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +
 							"Ironpulling is affected by the normal laws of physics. If a lurcher were to pull on something that weighs more than them, they'd be pulled towards it. If they pulled on something lighter, the object would move. If both were of similar weight, they'd both move."));
+					pages.add(new BookStuff.TextPage("A lurcher can pull on items that contain metal by pressing " + PatchouliTextFormat.Keybind("key.cosmere.allomancy.pull")));
+					// Not sure the right keybinding format. You should fact-check this.
 					break;
 				case STEEL:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". Steel is an Allomantic metal and an alloy of Iron. When burnt, Steel allows the user to push against nearby metal objects. Steelpushing is affected by the laws of physics. If a coinshot were to push on something that weighs more than them, they'd be pushed away. "));
-					pages.add(new BookStuff.TextPage("If they pushed on something lighter, the object would move. Clever use of Steelpushing can lead to a pseudo flight through use of small metal objects, such as coins or nuggets. Many coinshots generally carry around a pouch of coins, for ease of access."));
-					pages.add(new BookStuff.CraftingPage("allomancy:coin_pouch"));
+					pages.add(new BookStuff.TextPage("If they pushed on something lighter, the object would move. Clever use of Steelpushing can lead to a pseudo flight through use of small metal objects, such as coins or nuggets. Many coinshots generally carry around a pouch of coins, for ease of access. A Coinshot can access their abilities by pressing " + PatchouliTextFormat.Keybind( "key.cosmere.allomancy.push")));
+					// Check Keybinding
+					//pages.add(new BookStuff.CraftingPage("allomancy:coin_pouch")); -- redirect to coin pouch page instead.
+					pages.add(new BookStuff.RelationsPage("Coin Pouch", "coinPouchEntry"));
 					break;
 				case TIN:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +
@@ -117,16 +122,19 @@ public class PatchouliAllomancyCategory
 					break;
 				case PEWTER:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +
-							"While burning pewter, a pewterarm becomes faster, considerably stronger, and more resistant to punishment."));
+							"While burning pewter, a pewterarm becomes faster, considerably stronger, and more resistant to punishment. However, they need to be careful because if they run out of pewter to burn, they will immediately feel all the pain they were shrugging off. This can mean instant death in extreme cases."));
 					//"The major problem with pewter is that when it runs out, a large portion of the pain and injury that you resisted using the pewter hits you at once, potentially resulting in death. $(#f00)(NYI)$()";
 					break;
 				case ZINC:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +
-							"A creature being manipulated by a rioter will act far more aggressive, turning even the most pacified of animals into bloodthirsty beasts."));
+							"A creature being manipulated by a rioter will act far more aggressive, turning even the most pacified of animals into bloodthirsty beasts." + " A rioter can use their powers by pressing either " + PatchouliTextFormat.Keybind("key.cosmere.allomacy.riot") + " or " + PatchouliTextFormat.Keybind("key.cosmere.manifestation.use.active") + "."));
+					pages.add(new BookStuff.TextPage("Rioters have reported recently that their allomancy has been acting different, resulting in creatures that seem confused. (This feature is bugged.)"));
 					break;
 				case BRASS:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +
-							"A creature being manipulated by a soother will act far more pacified, reducing their willingness to engage in combat."));
+							"A creature being manipulated by a soother will act far more pacified, reducing their willingness to engage in combat." +
+							" A soother can use their powers by pressing either " + PatchouliTextFormat.Keybind("k:cosmere.allomacy.soothe") + " or " + PatchouliTextFormat.Keybind("key.cosmere.manifestation.use.active") + "."));
+					pages.add(new BookStuff.TextPage("Soothers have reported recently that their allomancy has been acting different, resulting in creatures that seem confused. (This feature is bugged.)"));
 					break;
 				case COPPER:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +
@@ -139,7 +147,8 @@ public class PatchouliAllomancyCategory
 					break;
 				case ALUMINUM:
 					pages.add(new BookStuff.TextPage("A misting who can only burn " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\" as they gain no discernible effect from burning their metal. " +
-							"A mistborn burning aluminum will wipe all their metal reserves, including aluminum."));
+							"A mistborn burning aluminum will wipe all their metal reserves, including aluminum." + "I have heard rumors that an Aluminum Gnat of considerable power could clear the effects of other sources of investiture or impurities from their bodies, " +
+							"but this has not been confirmed to me. (Not yet implemented)"));
 					break;
 				case DURALUMIN:
 					//add extra note so that these people will know of their shame.
@@ -148,19 +157,19 @@ public class PatchouliAllomancyCategory
 					break;
 				case CHROMIUM:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +
-							"A leecher gazing upon an allomancer can deplete their metal reserves, as if they were burning aluminum themselves."));
+							"A leecher gazing upon an allomancer can deplete their metal reserves, as if the target were burning aluminum themselves."));
 					break;
 				case NICROSIL:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +
-							"A nicroburst can empower the allomancy of another with physical contact, as if they were burning duralumin themselves."));
+							"A nicroburst can empower the allomancy of another with physical contact, as if the target were burning duralumin themselves."));
 					break;
 				case CADMIUM:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +
-							"a pulser creates a bubble around them in which everyone moves faster around them."));
+							"a pulser creates a bubble around them in which time slows down. To anyone inside this time bubble, everything outside appears to move faster."));
 					break;
 				case BENDALLOY:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +
-							"A slider creates a bubble around them in which everyone moves slower around them."));
+							"A slider creates a bubble around them in which time speeds up. To anyone inside of the time bubble, everything outside appears to move much more slowly."));
 					break;
 				case GOLD:
 					pages.add(new BookStuff.TextPage("A misting who burns " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(mistingName) + "\". " +

--- a/src/datagen/cosmeretools/java/leaf/cosmere/tools/patchouli/PatchouliToolsCategory.java
+++ b/src/datagen/cosmeretools/java/leaf/cosmere/tools/patchouli/PatchouliToolsCategory.java
@@ -15,8 +15,8 @@ public class PatchouliToolsCategory
 	{
 		BookStuff.Category tools = new BookStuff.Category(
 				"tools",
-				"Tools description that says some stuff.",
-				"minecraft:paper");
+				"Metalworkers recently discovered that other metals besides iron and gold can be worked to make tools and armor.",
+				"cosmere:pewter_pickaxe");
 		tools.sortnum = 99;
 		tools.secret = true;
 		categories.add(tools);

--- a/src/datagen/feruchemy/java/leaf/cosmere/feruchemy/patchouli/PatchouliFeruchemyCategory.java
+++ b/src/datagen/feruchemy/java/leaf/cosmere/feruchemy/patchouli/PatchouliFeruchemyCategory.java
@@ -43,7 +43,7 @@ public class PatchouliFeruchemyCategory
 		BookStuff.Entry Compounding = new BookStuff.Entry("Compounding", feruchemy, feruchemy.icon);
 		pages.add(new BookStuff.TextPage("A curious loophole in the systems of investiture on this planet has been discovered. It involves a metalborn with the allomantic and feruchemical " +
 				"abilities of the same metal to burn one of their feruchemical metalminds, essentially creating a new allomantic metal that releases the stored feruchemical charge tenfold."));
-		pages.add(new BookStuff.TextPage("This is activated by setting your allomantic power to a negative mode called Compounding and Flared Compounding, which spends allomantic charges to gain feruchemical stores quickly."));
+		pages.add(new BookStuff.TextPage("This is activated by setting your allomantic power to a negative mode called Compounding and Flared Compounding, which spends allomantic charges to gain feruchemical stores quickly. " + "This is only accessible to Twinborn who have the same Allomantic and Feruchemic metals."));
 		Compounding.pages = pages.toArray(BookStuff.Page[]::new);
 		pages.clear();
 		entries.add(Compounding);
@@ -123,7 +123,7 @@ public class PatchouliFeruchemyCategory
 					break;
 				case CADMIUM:
 					pages.add(new BookStuff.TextPage("A ferring who taps " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(ferringName) + "\", and stores Breaths. " +
-							"While storing, a Gasper will find it difficult to breath. Storing too much may make them suffocate. tapping allows them to hold their breath for far longer periods of time."));
+							"While storing, a Gasper will find it difficult to breathe. Storing too much may make them suffocate. tapping allows them to hold their breath for far longer periods of time."));
 					break;
 				case BENDALLOY:
 					pages.add(new BookStuff.TextPage("A ferring who taps " + PatchouliTextFormat.Thing(metalName) + " is known as a \"" + PatchouliTextFormat.Thing(ferringName) + "\", and stores Saturation. " +


### PR DESCRIPTION
## Changes proposed in this pull request:
Changes to Allomancy, Feruchemy, and Cosmere tools patchouli guides. Adds keybinds to steel, iron, zinc, and brass allomancy pages. Adds mentions of future features for aluminum allomancy. Clarifies use on Chromium, Nicrosil, Cadmium, and Bendalloy Allomancy.
 Corrects Typo on Feruchemical Cadmium and clarifies compounding.
 Edits Cosmere tools main page slightly.
 Remember to check my work on the Allomancy guide. I am uncertain if I implemented the keybind formats and coin bag page redirect correctly.