### PR TITLE
Fix Bug for Filling Metal Reserves with Metal Vial Item

### DIFF
--- a/src/allomancy/java/leaf/cosmere/allomancy/common/eventHandlers/AllomancyEntityEventHandler.java
+++ b/src/allomancy/java/leaf/cosmere/allomancy/common/eventHandlers/AllomancyEntityEventHandler.java
@@ -64,7 +64,7 @@ public class AllomancyEntityEventHandler
 					return;
 				}
 
-				MiscHelper.consumeNugget(target, stack);
+				MiscHelper.consumeNugget(target, stack, 1);
 				stack.shrink(1);
 			}
 		}
@@ -91,7 +91,7 @@ public class AllomancyEntityEventHandler
 			{
 				return;
 			}
-			MiscHelper.consumeNugget(livingEntity, event.getItem());
+			MiscHelper.consumeNugget(livingEntity, event.getItem(), 1);
 		}
 	}
 

--- a/src/allomancy/java/leaf/cosmere/allomancy/common/items/MetalVialItem.java
+++ b/src/allomancy/java/leaf/cosmere/allomancy/common/items/MetalVialItem.java
@@ -139,7 +139,7 @@ public class MetalVialItem extends BaseItem implements IHasMetalType
 					}
 
 				}
-				MiscHelper.consumeNugget(entityLiving, newStack);
+				MiscHelper.consumeNugget(entityLiving, newStack, amount);
 			}
 		});
 

--- a/src/allomancy/java/leaf/cosmere/allomancy/common/utils/MiscHelper.java
+++ b/src/allomancy/java/leaf/cosmere/allomancy/common/utils/MiscHelper.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 public class MiscHelper
 {
 
-	public static void consumeNugget(LivingEntity livingEntity, ItemStack itemStack)
+	public static void consumeNugget(LivingEntity livingEntity, ItemStack itemStack, int amount)
 	{
 		if (livingEntity.level().isClientSide) return;
 
@@ -46,25 +46,25 @@ public class MiscHelper
 				}
 				else if(godItem.getMetalType() == Metals.MetalType.ATIUM)
 				{
-					eatMetal(godItem.getMetalType(), livingEntity);
+					eatMetal(godItem.getMetalType(), livingEntity, amount);
 				}
 			}
 		}
 		else if(itemStack.getItem() instanceof IHasMetalType metalItem)
 		{
-			eatMetal(metalItem.getMetalType(), livingEntity);
+			eatMetal(metalItem.getMetalType(), livingEntity, amount);
 		}
 		else if(itemStack.getItem() == Items.IRON_NUGGET)
 		{
-			eatMetal(Metals.MetalType.IRON, livingEntity);
+			eatMetal(Metals.MetalType.IRON, livingEntity, amount);
 		}
 		else if(itemStack.getItem() == Items.GOLD_NUGGET)
 		{
-			eatMetal(Metals.MetalType.GOLD, livingEntity);
+			eatMetal(Metals.MetalType.GOLD, livingEntity, amount);
 		}
 	}
 
-	private static void eatMetal(Metals.MetalType metalType, LivingEntity livingEntity)
+	private static void eatMetal(Metals.MetalType metalType, LivingEntity livingEntity, int amount)
 	{
 		SpiritwebCapability.get(livingEntity).ifPresent(iSpiritweb ->
 		{
@@ -72,7 +72,7 @@ public class MiscHelper
 			if (metalType.hasAssociatedManifestation()) //ignore metals without manifestations, that's handled in feruchemy
 			{
 				//add to metal stored
-				final int addAmount = metalType.getAllomancyBurnTimeSeconds();
+				final int addAmount = metalType.getAllomancyBurnTimeSeconds() * amount;
 				AllomancySpiritwebSubmodule allo = (AllomancySpiritwebSubmodule) spiritweb.getSubmodule(Manifestations.ManifestationTypes.ALLOMANCY);
 				allo.adjustIngestedMetal(metalType, addAmount, true);
 			}


### PR DESCRIPTION
## Changes proposed in this pull request:
**Defect:** When using the metal vial item, only the base amount of burntime is added for each nugget regardless of the nugget count.
#### Changes
- Readd `amount` parameter to the consume nugget function
- `MetalVialItem` is able to call `consumeNugget` for multiple nuggets