### PR TITLE
Fix sand spreader display name translation

### DIFF
--- a/src/sandmastery/java/leaf/cosmere/sandmastery/common/blocks/entities/SandSpreaderBE.java
+++ b/src/sandmastery/java/leaf/cosmere/sandmastery/common/blocks/entities/SandSpreaderBE.java
@@ -94,7 +94,7 @@ public class SandSpreaderBE extends BlockEntity implements MenuProvider
 	@Override
 	public Component getDisplayName()
 	{
-		return Component.literal("Sand Spreading Tub"); // TODO Translations
+		return Component.translatable("block.sandmastery.sand_spreading_tub");
 	}
 
 	@Nullable


### PR DESCRIPTION
- Replace hardcoded display name with translatable component
- Changes `Component.literal("Sand Spreading Tub")` to `Component.translatable("block.sandmastery.sand_spreading_tub")`
- Enables proper localization support for the Sand Spreader block entity display name
- Resolves TODO comment about missing translations