### PR TITLE
[Feruchemy] fix bronze allowing bed sleep in non-natural dimensions (#206)

### DIFF
--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyBronze.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyBronze.java
@@ -191,8 +191,13 @@ public class FeruchemyBronze extends FeruchemyManifestation
 
 	public void sleepCheck(SleepingLocationCheckEvent event)
 	{
-		if (event.getEntity() instanceof Player)
+		if (event.getEntity() instanceof Player player)
 		{
+			if (!player.level().dimensionType().natural())
+			{
+				return;
+			}
+
 			SpiritwebCapability.get(event.getEntity()).ifPresent(iSpiritweb ->
 			{
 				if (isActive(iSpiritweb))
@@ -200,7 +205,6 @@ public class FeruchemyBronze extends FeruchemyManifestation
 					event.setResult(Event.Result.ALLOW);
 				}
 			});
-
 		}
 	}
 }


### PR DESCRIPTION
Closes #206

## Summary
- Feruchemical bronze's `SleepingLocationCheckEvent` handler was unconditionally returning `ALLOW` when bronze was active, bypassing vanilla's bed explosion mechanic in the Nether and End
- Added a `dimensionType().natural()` check to the event handler so it exits early in non-natural dimensions, consistent with the existing check in `canSleep()`

## Test plan
- [ ] Verify feruchemical bronze tapping still allows sleeping in the Overworld at night without monsters nearby
- [ ] Verify attempting to use a bed in the Nether with feruchemical bronze active still causes an explosion (no longer bypassed)
- [ ] Verify the End behaves the same as the Nether

🤖 Generated with [Claude Code](https://claude.com/claude-code)