### PR TITLE
[Sandmastery] Add command to clear overmastery

### DIFF
--- a/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/SandmasteryCommands.java
+++ b/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/SandmasteryCommands.java
@@ -2,6 +2,7 @@ package leaf.cosmere.sandmastery.common.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import leaf.cosmere.common.Cosmere;
+import leaf.cosmere.sandmastery.common.commands.subcommands.AddOvermasteryCommand;
 import leaf.cosmere.sandmastery.common.commands.subcommands.ClearOvermasteryCommand;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -11,6 +12,7 @@ public class SandmasteryCommands
 	public static void register(CommandDispatcher<CommandSourceStack> dispatcher)
 	{
 		dispatcher.register(Commands.literal(Cosmere.MODID)
+				.then(AddOvermasteryCommand.register(dispatcher))
 				.then(ClearOvermasteryCommand.register(dispatcher))
 		);
 	}

--- a/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/SandmasteryCommands.java
+++ b/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/SandmasteryCommands.java
@@ -1,0 +1,17 @@
+package leaf.cosmere.sandmastery.common.commands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import leaf.cosmere.common.Cosmere;
+import leaf.cosmere.sandmastery.common.commands.subcommands.ClearOvermasteryCommand;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+
+public class SandmasteryCommands
+{
+	public static void register(CommandDispatcher<CommandSourceStack> dispatcher)
+	{
+		dispatcher.register(Commands.literal(Cosmere.MODID)
+				.then(ClearOvermasteryCommand.register(dispatcher))
+		);
+	}
+}

--- a/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/subcommands/AddOvermasteryCommand.java
+++ b/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/subcommands/AddOvermasteryCommand.java
@@ -52,6 +52,7 @@ public class AddOvermasteryCommand extends ModCommand
 						ribbons,
 						AttributeModifier.Operation.ADDITION
 				));
+				context.getSource().sendSuccess(() -> Component.literal(String.format("Filled overmastery slot 1 with %d ribbons for %s", ribbons, player.getName().getString())), true);
 			}
 			else if (availableRibbons.getModifier(SandmasteryAttributes.OVERMASTERY_SECONDARY_UUID) == null)
 			{
@@ -61,6 +62,7 @@ public class AddOvermasteryCommand extends ModCommand
 						ribbons,
 						AttributeModifier.Operation.ADDITION
 				));
+				context.getSource().sendSuccess(() -> Component.literal(String.format("Filled overmastery slot 2 with %d ribbons for %s", ribbons, player.getName().getString())), true);
 			}
 			else
 			{

--- a/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/subcommands/AddOvermasteryCommand.java
+++ b/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/subcommands/AddOvermasteryCommand.java
@@ -1,0 +1,80 @@
+package leaf.cosmere.sandmastery.common.commands.subcommands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import leaf.cosmere.common.commands.subcommands.ModCommand;
+import leaf.cosmere.sandmastery.common.registries.SandmasteryAttributes;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+
+import java.util.Collection;
+
+public class AddOvermasteryCommand extends ModCommand
+{
+	public static ArgumentBuilder<CommandSourceStack, ?> register(CommandDispatcher<CommandSourceStack> dispatcher)
+	{
+		return Commands.literal("add_overmastery")
+				.requires(context -> context.hasPermission(2))
+				.then(Commands.argument("ribbons", IntegerArgumentType.integer(1))
+						.executes(AddOvermasteryCommand::addOvermastery)
+						.then(Commands.argument("target", EntityArgument.players())
+								.requires(context -> context.hasPermission(2))
+								.executes(AddOvermasteryCommand::addOvermastery)));
+	}
+
+	private static int addOvermastery(CommandContext<CommandSourceStack> context) throws CommandSyntaxException
+	{
+		int ribbons = IntegerArgumentType.getInteger(context, "ribbons");
+		Collection<ServerPlayer> players = getPlayers(context, 3);
+
+		for (ServerPlayer player : players)
+		{
+			AttributeInstance availableRibbons = player.getAttribute(SandmasteryAttributes.RIBBONS.getAttribute());
+
+			if (availableRibbons == null)
+			{
+				continue;
+			}
+
+			if (availableRibbons.getModifier(SandmasteryAttributes.OVERMASTERY_UUID) == null)
+			{
+				availableRibbons.addPermanentModifier(new AttributeModifier(
+						SandmasteryAttributes.OVERMASTERY_UUID,
+						String.format("%s - gained %s ribbons: %s", "Overmastery", ribbons, SandmasteryAttributes.OVERMASTERY_UUID),
+						ribbons,
+						AttributeModifier.Operation.ADDITION
+				));
+			}
+			else if (availableRibbons.getModifier(SandmasteryAttributes.OVERMASTERY_SECONDARY_UUID) == null)
+			{
+				availableRibbons.addPermanentModifier(new AttributeModifier(
+						SandmasteryAttributes.OVERMASTERY_SECONDARY_UUID,
+						String.format("%s - gained %s ribbons: %s", "Overmastery", ribbons, SandmasteryAttributes.OVERMASTERY_SECONDARY_UUID),
+						ribbons,
+						AttributeModifier.Operation.ADDITION
+				));
+			}
+			else
+			{
+				context.getSource().sendFailure(Component.literal("Both overmastery slots are filled; use clear_overmastery first"));
+				return 0;
+			}
+		}
+
+		return SINGLE_SUCCESS;
+	}
+
+	@Override
+	public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException
+	{
+		return SINGLE_SUCCESS;
+	}
+}

--- a/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/subcommands/ClearOvermasteryCommand.java
+++ b/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/subcommands/ClearOvermasteryCommand.java
@@ -1,0 +1,61 @@
+package leaf.cosmere.sandmastery.common.commands.subcommands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import leaf.cosmere.common.commands.subcommands.ModCommand;
+import leaf.cosmere.sandmastery.common.registries.SandmasteryAttributes;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+
+import java.util.Collection;
+
+public class ClearOvermasteryCommand extends ModCommand
+{
+	public static ArgumentBuilder<CommandSourceStack, ?> register(CommandDispatcher<CommandSourceStack> dispatcher)
+	{
+		return Commands.literal("clear_overmastery")
+				.requires(context -> context.hasPermission(2))
+				.executes(ClearOvermasteryCommand::clearOvermastery)
+				.then(Commands.argument("target", EntityArgument.players())
+						.requires(context -> context.hasPermission(2))
+						.executes(ClearOvermasteryCommand::clearOvermastery));
+	}
+
+	private static int clearOvermastery(CommandContext<CommandSourceStack> context) throws CommandSyntaxException
+	{
+		Collection<ServerPlayer> players = getPlayers(context, 3);
+
+		for (ServerPlayer player : players)
+		{
+			AttributeInstance availableRibbons = player.getAttribute(SandmasteryAttributes.RIBBONS.getAttribute());
+
+			if (availableRibbons == null)
+			{
+				continue;
+			}
+
+			if (availableRibbons.getModifier(SandmasteryAttributes.OVERMASTERY_UUID) != null)
+			{
+				availableRibbons.removeModifier(SandmasteryAttributes.OVERMASTERY_UUID);
+			}
+
+			if (availableRibbons.getModifier(SandmasteryAttributes.OVERMASTERY_SECONDARY_UUID) != null)
+			{
+				availableRibbons.removeModifier(SandmasteryAttributes.OVERMASTERY_SECONDARY_UUID);
+			}
+		}
+
+		return SINGLE_SUCCESS;
+	}
+
+	@Override
+	public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException
+	{
+		return SINGLE_SUCCESS;
+	}
+}

--- a/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/subcommands/ClearOvermasteryCommand.java
+++ b/src/sandmastery/java/leaf/cosmere/sandmastery/common/commands/subcommands/ClearOvermasteryCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import leaf.cosmere.common.commands.subcommands.ModCommand;
 import leaf.cosmere.sandmastery.common.registries.SandmasteryAttributes;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.server.level.ServerPlayer;
@@ -48,6 +49,8 @@ public class ClearOvermasteryCommand extends ModCommand
 			{
 				availableRibbons.removeModifier(SandmasteryAttributes.OVERMASTERY_SECONDARY_UUID);
 			}
+
+			context.getSource().sendSuccess(() -> Component.literal(String.format("Cleared overmastery for %s", player.getName().getString())), true);
 		}
 
 		return SINGLE_SUCCESS;

--- a/src/sandmastery/java/leaf/cosmere/sandmastery/common/eventHandlers/SandmasteryCommonEventHandler.java
+++ b/src/sandmastery/java/leaf/cosmere/sandmastery/common/eventHandlers/SandmasteryCommonEventHandler.java
@@ -19,7 +19,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod.EventBusSubscriber(modid = Sandmastery.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
-public class SandmasteryEntityEventHandler
+public class SandmasteryCommonEventHandler
 {
 	@SubscribeEvent
 	public static void registerCommands(RegisterCommandsEvent event)

--- a/src/sandmastery/java/leaf/cosmere/sandmastery/common/eventHandlers/SandmasteryEntityEventHandler.java
+++ b/src/sandmastery/java/leaf/cosmere/sandmastery/common/eventHandlers/SandmasteryEntityEventHandler.java
@@ -8,10 +8,12 @@ import leaf.cosmere.api.Manifestations;
 import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.sandmastery.common.Sandmastery;
 import leaf.cosmere.sandmastery.common.capabilities.SandmasterySpiritwebSubmodule;
+import leaf.cosmere.sandmastery.common.commands.SandmasteryCommands;
 import leaf.cosmere.sandmastery.common.config.SandmasteryConfigs;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.PotionItem;
+import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -19,6 +21,12 @@ import net.minecraftforge.fml.common.Mod;
 @Mod.EventBusSubscriber(modid = Sandmastery.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class SandmasteryEntityEventHandler
 {
+	@SubscribeEvent
+	public static void registerCommands(RegisterCommandsEvent event)
+	{
+		SandmasteryCommands.register(event.getDispatcher());
+	}
+
 	@SubscribeEvent
 	public static void onFinishUsingItem(LivingEntityUseItemEvent.Finish event)
 	{


### PR DESCRIPTION
Closes #190

## Summary
- Adds `/cosmere add_overmastery <ribbons> [target]` command to apply overmastery modifiers with a specified ribbon count; fills slot 1 first, then slot 2; returns an error if both are already filled
- Adds `/cosmere clear_overmastery [target]` command to remove overmastery modifiers; sends a single confirmation message per player
- Both commands provide feedback messages on success
- Renames `SandmasteryEntityEventHandler` to `SandmasteryCommonEventHandler`

## Test plan
- [x] Run `/cosmere add_overmastery <n>` — confirm slot 1 is filled and feedback is shown
- [x] Run `/cosmere add_overmastery <n>` again — confirm slot 2 is filled and feedback is shown
- [x] Run `/cosmere add_overmastery <n>` a third time — confirm error message about both slots being filled
- [x] Run `/cosmere clear_overmastery` — confirm both slots are removed and a single confirmation message is shown
- [x] Test all commands with an explicit `[target]` player
- [x] Confirm commands require permission level 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)