### PR TITLE
[Feruchemy] Refactor metalmind selection and charge logic

### DIFF
--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyManifestation.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyManifestation.java
@@ -99,9 +99,10 @@ public class FeruchemyManifestation extends Manifestation implements IHasMetalTy
 	public boolean canAfford(ISpiritweb data, boolean simulate)
 	{
 		int adjustAmount = getCost(data);
-		final ItemStack metalmind = MetalmindChargeHelper.adjustMetalmindChargeExact(data, metalType, adjustAmount, !simulate, true);
+		boolean success = MetalmindChargeHelper.adjustMetalmindCharges(
+				data, metalType, adjustAmount, !simulate, true);
 
-		if (!metalmind.isEmpty())
+		if (success)
 		{
 			return true;
 		}

--- a/src/main/java/leaf/cosmere/common/charge/ItemChargeHelper.java
+++ b/src/main/java/leaf/cosmere/common/charge/ItemChargeHelper.java
@@ -13,7 +13,6 @@ import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.common.compat.curios.CuriosCompat;
 import leaf.cosmere.common.items.CapWrapper;
 import net.minecraft.world.Container;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.util.LazyOptional;
@@ -39,39 +38,6 @@ public class ItemChargeHelper
 		List<ItemStack> toReturn = getChargeableItemStacks(acc);
 
 		return toReturn;
-	}
-
-	/** Returns all IChargeable items in priority order: hotbar → curios → armor → main inventory. */
-	public static List<ItemStack> getOrderedChargeables(Player player)
-	{
-		if (player == null)
-		{
-			return Collections.emptyList();
-		}
-
-		Inventory inv = player.getInventory();
-		List<ItemStack> result = new ArrayList<>();
-
-		for (int i = 0; i < 9; i++)
-		{
-			ItemStack s = inv.items.get(i);
-			if (!s.isEmpty() && s.getItem() instanceof IChargeable) result.add(s);
-		}
-
-		result.addAll(getChargeCurios(player));
-
-		for (ItemStack s : inv.armor)
-		{
-			if (!s.isEmpty() && s.getItem() instanceof IChargeable) result.add(s);
-		}
-
-		for (int i = 9; i < inv.items.size(); i++)
-		{
-			ItemStack s = inv.items.get(i);
-			if (!s.isEmpty() && s.getItem() instanceof IChargeable) result.add(s);
-		}
-
-		return result;
 	}
 
 	public static List<ItemStack> getChargeCurios(Player player)
@@ -163,7 +129,7 @@ public class ItemChargeHelper
 		boolean isStoringIdentity = false;
 		{
 			//do aluminum checks
-			Optional<ISpiritweb> data = SpiritwebCapability.get(player).filter(obj -> true);
+			Optional<ISpiritweb> data = SpiritwebCapability.get(player);
 			if (data.isPresent())
 			{
                 isStoringIdentity = Manifestations.ManifestationTypes.FERUCHEMY.getManifestation(Metals.MetalType.ALUMINUM.getID()).getMode(data.get()) > 0;
@@ -239,7 +205,7 @@ public class ItemChargeHelper
 			}
 		}
 
-		return accessible.get(0);
+		return accessible.isEmpty() ? ItemStack.EMPTY : accessible.get(0);
 	}
 
 

--- a/src/main/java/leaf/cosmere/common/charge/ItemChargeHelper.java
+++ b/src/main/java/leaf/cosmere/common/charge/ItemChargeHelper.java
@@ -13,6 +13,7 @@ import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.common.compat.curios.CuriosCompat;
 import leaf.cosmere.common.items.CapWrapper;
 import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.util.LazyOptional;
@@ -38,6 +39,39 @@ public class ItemChargeHelper
 		List<ItemStack> toReturn = getChargeableItemStacks(acc);
 
 		return toReturn;
+	}
+
+	/** Returns all IChargeable items in priority order: hotbar → curios → armor → main inventory. */
+	public static List<ItemStack> getOrderedChargeables(Player player)
+	{
+		if (player == null)
+		{
+			return Collections.emptyList();
+		}
+
+		Inventory inv = player.getInventory();
+		List<ItemStack> result = new ArrayList<>();
+
+		for (int i = 0; i < 9; i++)
+		{
+			ItemStack s = inv.items.get(i);
+			if (!s.isEmpty() && s.getItem() instanceof IChargeable) result.add(s);
+		}
+
+		result.addAll(getChargeCurios(player));
+
+		for (ItemStack s : inv.armor)
+		{
+			if (!s.isEmpty() && s.getItem() instanceof IChargeable) result.add(s);
+		}
+
+		for (int i = 9; i < inv.items.size(); i++)
+		{
+			ItemStack s = inv.items.get(i);
+			if (!s.isEmpty() && s.getItem() instanceof IChargeable) result.add(s);
+		}
+
+		return result;
 	}
 
 	public static List<ItemStack> getChargeCurios(Player player)
@@ -124,19 +158,6 @@ public class ItemChargeHelper
 	}
 
 
-	public static ItemStack adjustChargeExact(Player player, int chargeToGet, boolean remove)
-	{
-		return adjustChargeExact(player, chargeToGet, remove, false);
-	}
-
-	public static ItemStack adjustChargeExact(Player player, int chargeToGet, boolean remove, boolean checkPlayer)
-	{
-		List<ItemStack> items = getChargeItems(player);
-		List<ItemStack> acc = getChargeCurios(player);
-
-		return adjustChargeExact(player, chargeToGet, remove, checkPlayer, items, acc);
-	}
-
 	public static ItemStack adjustChargeExact(Player player, int adjustValue, boolean doAdjust, boolean checkPlayer, List<ItemStack> items, List<ItemStack> acc)
 	{
 		boolean isStoringIdentity = false;
@@ -149,43 +170,76 @@ public class ItemChargeHelper
 			}
 		}
 
+		boolean storing = adjustValue > 0;
+		int needed = Math.abs(adjustValue);
+
+		// Pass 1: collect accessible stacks and verify the full cost can be met.
+		List<ItemStack> accessible = new ArrayList<>();
+		int totalAvailable = 0;
+
 		for (ItemStack stackInSlot : Iterables.concat(items, acc))
 		{
 			IChargeable chargeItemSlot = (IChargeable) stackInSlot.getItem();
-			boolean storing = adjustValue > 0;
-
 			int slotCharge = chargeItemSlot.getCharge(stackInSlot);
 			int slotMaxCharge = chargeItemSlot.getMaxCharge(stackInSlot);
 
-			//if draining, skip empty.
-			if (!storing && slotCharge <= 0 || storing && slotCharge >= slotMaxCharge)
+			int available = storing ? (slotMaxCharge - slotCharge) : slotCharge;
+			if (available <= 0)
 			{
 				continue;
 			}
 
-			boolean playerUnableToAccess = !chargeItemSlot.trySetAttunedPlayer(stackInSlot, player);
+			// Read-only access check — no NBT writes in the check pass.
 			final UUID attunedPlayer = chargeItemSlot.getAttunedPlayer(stackInSlot);
-			if (checkPlayer && playerUnableToAccess //if we need to make sure the player has access and they do not
-					|| //or if the player is trying to store in an unsealed metalmind but have identity
-					storing && !isStoringIdentity && attunedPlayer != null && attunedPlayer.compareTo(Constants.NBT.UNKEYED_UUID) == 0)
+			if (checkPlayer && attunedPlayer != null
+					&& attunedPlayer.compareTo(player.getUUID()) != 0
+					&& attunedPlayer.compareTo(Constants.NBT.UNKEYED_UUID) != 0)
 			{
-				continue;
+				continue; // attuned to a different player
+			}
+			if (storing && !isStoringIdentity && attunedPlayer != null && attunedPlayer.compareTo(Constants.NBT.UNKEYED_UUID) == 0)
+			{
+				continue; // can't store in an unsealed metalmind without storing identity
 			}
 
+			accessible.add(stackInSlot);
+			totalAvailable += available;
 
-			if ((storing && (slotCharge + adjustValue) <= slotMaxCharge)//storing and can fit in this item
-					|| !storing && slotCharge >= (-adjustValue))
+			if (totalAvailable >= needed)
 			{
-				if (doAdjust)
-				{
-					chargeItemSlot.adjustCharge(stackInSlot, adjustValue);
-				}
-
-				return stackInSlot;
+				break;
 			}
 		}
 
-		return ItemStack.EMPTY;
+		if (totalAvailable < needed)
+		{
+			return ItemStack.EMPTY;
+		}
+
+		// Pass 2: apply the charge adjustment across the cached stacks.
+		// trySetAttunedPlayer is called here so attunement side effects only happen when charge actually moves.
+		if (doAdjust)
+		{
+			int remaining = needed;
+			for (ItemStack stackInSlot : accessible)
+			{
+				if (remaining <= 0)
+				{
+					break;
+				}
+				IChargeable chargeItemSlot = (IChargeable) stackInSlot.getItem();
+				int slotCharge = chargeItemSlot.getCharge(stackInSlot);
+				int slotMaxCharge = chargeItemSlot.getMaxCharge(stackInSlot);
+				int amount = storing
+						? Math.min(remaining, slotMaxCharge - slotCharge)
+						: Math.min(remaining, slotCharge);
+				chargeItemSlot.trySetAttunedPlayer(stackInSlot, player);
+				chargeItemSlot.adjustCharge(stackInSlot, storing ? amount : -amount);
+				remaining -= amount;
+			}
+		}
+
+		return accessible.get(0);
 	}
 
 

--- a/src/main/java/leaf/cosmere/common/charge/MetalmindChargeHelper.java
+++ b/src/main/java/leaf/cosmere/common/charge/MetalmindChargeHelper.java
@@ -78,7 +78,7 @@ public class MetalmindChargeHelper
 
 		boolean isStoringIdentity = false;
 		{
-			Optional<ISpiritweb> spiritwebData = SpiritwebCapability.get(player).filter(obj -> true);
+			Optional<ISpiritweb> spiritwebData = SpiritwebCapability.get(player);
 			if (spiritwebData.isPresent())
 			{
 				isStoringIdentity = Manifestations.ManifestationTypes.FERUCHEMY.getManifestation(Metals.MetalType.ALUMINUM.getID()).getMode(spiritwebData.get()) > 0;
@@ -175,9 +175,10 @@ public class MetalmindChargeHelper
 			if (isValid.test(s)) result.add(s);
 		}
 
-		List<ItemStack> curios = ItemChargeHelper.getChargeCurios(player);
-		curios.removeIf(isInvalid);
-		result.addAll(curios);
+		for (ItemStack s : ItemChargeHelper.getChargeCurios(player))
+		{
+			if (isValid.test(s)) result.add(s);
+		}
 
 		for (ItemStack s : inv.armor)
 		{

--- a/src/main/java/leaf/cosmere/common/charge/MetalmindChargeHelper.java
+++ b/src/main/java/leaf/cosmere/common/charge/MetalmindChargeHelper.java
@@ -4,13 +4,21 @@
 
 package leaf.cosmere.common.charge;
 
+import leaf.cosmere.api.Constants;
+import leaf.cosmere.api.Manifestations;
 import leaf.cosmere.api.Metals;
 import leaf.cosmere.api.spiritweb.ISpiritweb;
+import leaf.cosmere.common.cap.entity.SpiritwebCapability;
 import leaf.cosmere.common.items.ChargeableMetalCurioItem;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Predicate;
 
 public class MetalmindChargeHelper
@@ -44,18 +52,144 @@ public class MetalmindChargeHelper
 
 	public static ItemStack adjustMetalmindChargeExact(Player player, Metals.MetalType metalType, int adjustValue, boolean remove, boolean checkPlayer)
 	{
-		List<ItemStack> items = ItemChargeHelper.getChargeItems(player);
-		List<ItemStack> acc = ItemChargeHelper.getChargeCurios(player);
+		List<ItemStack> ordered = buildOrderedMetalminds(player, metalType);
 
-		//remove items that don't match the metal type we are looking for
-		items.removeIf(getIsItemInvalidMetalmind(metalType));
-		acc.removeIf(getIsItemInvalidMetalmind(metalType));
-
-		if (items.isEmpty() && acc.isEmpty())
+		if (ordered.isEmpty())
 		{
 			return ItemStack.EMPTY;
 		}
 
-		return ItemChargeHelper.adjustChargeExact(player, adjustValue, remove, checkPlayer, items, acc);
+		return ItemChargeHelper.adjustChargeExact(player, adjustValue, remove, checkPlayer, ordered, Collections.emptyList());
+	}
+
+	/**
+	 * Checks whether the full cost can be met across all accessible metalminds, then (if doAdjust)
+	 * drains/stores from them in priority order. Never partially applies: returns false without
+	 * touching any metalmind if the total available charge is less than the required amount.
+	 *
+	 * @return true only if the full cost could be (and was, when doAdjust=true) satisfied
+	 */
+	public static boolean adjustMetalmindCharges(ISpiritweb data, Metals.MetalType metalType, int adjustValue, boolean doAdjust, boolean checkPlayer)
+	{
+		if (!(data.getLiving() instanceof Player player))
+		{
+			return false;
+		}
+
+		boolean isStoringIdentity = false;
+		{
+			Optional<ISpiritweb> spiritwebData = SpiritwebCapability.get(player).filter(obj -> true);
+			if (spiritwebData.isPresent())
+			{
+				isStoringIdentity = Manifestations.ManifestationTypes.FERUCHEMY.getManifestation(Metals.MetalType.ALUMINUM.getID()).getMode(spiritwebData.get()) > 0;
+			}
+		}
+
+		boolean storing = adjustValue > 0;
+		int needed = Math.abs(adjustValue);
+
+		// Pass 1: collect accessible metalminds and verify the full cost can be met.
+		List<ItemStack> accessible = new ArrayList<>();
+		int totalAvailable = 0;
+
+		for (ItemStack stackInSlot : buildOrderedMetalminds(player, metalType))
+		{
+			IChargeable chargeItemSlot = (IChargeable) stackInSlot.getItem();
+			int slotCharge = chargeItemSlot.getCharge(stackInSlot);
+			int slotMaxCharge = chargeItemSlot.getMaxCharge(stackInSlot);
+
+			int available = storing ? (slotMaxCharge - slotCharge) : slotCharge;
+			if (available <= 0)
+			{
+				continue;
+			}
+
+			// Read-only access check — no NBT writes in the check pass.
+			UUID attunedPlayer = chargeItemSlot.getAttunedPlayer(stackInSlot);
+			if (checkPlayer && attunedPlayer != null
+					&& attunedPlayer.compareTo(player.getUUID()) != 0
+					&& attunedPlayer.compareTo(Constants.NBT.UNKEYED_UUID) != 0)
+			{
+				continue; // attuned to a different player
+			}
+			if (storing && !isStoringIdentity && attunedPlayer != null && attunedPlayer.compareTo(Constants.NBT.UNKEYED_UUID) == 0)
+			{
+				continue; // can't store in an unsealed metalmind without storing identity
+			}
+
+			accessible.add(stackInSlot);
+			totalAvailable += available;
+
+			if (totalAvailable >= needed)
+			{
+				break; // no need to keep scanning once we know it's affordable
+			}
+		}
+
+		if (totalAvailable < needed)
+		{
+			return false;
+		}
+
+		// Pass 2: apply the charge adjustment across the cached metalminds.
+		// trySetAttunedPlayer is called here so attunement side effects only happen when charge actually moves.
+		if (doAdjust)
+		{
+			int remaining = needed;
+			for (ItemStack stackInSlot : accessible)
+			{
+				if (remaining <= 0)
+				{
+					break;
+				}
+				IChargeable chargeItemSlot = (IChargeable) stackInSlot.getItem();
+				int slotCharge = chargeItemSlot.getCharge(stackInSlot);
+				int slotMaxCharge = chargeItemSlot.getMaxCharge(stackInSlot);
+				int amount = storing
+						? Math.min(remaining, slotMaxCharge - slotCharge)
+						: Math.min(remaining, slotCharge);
+				chargeItemSlot.trySetAttunedPlayer(stackInSlot, player);
+				chargeItemSlot.adjustCharge(stackInSlot, storing ? amount : -amount);
+				remaining -= amount;
+			}
+		}
+
+		return true;
+	}
+
+	/** Builds an ordered list of metalminds: hotbar → curios → armor → main inventory. */
+	private static List<ItemStack> buildOrderedMetalminds(Player player, Metals.MetalType metalType)
+	{
+		Predicate<ItemStack> isInvalid = getIsItemInvalidMetalmind(metalType);
+		Predicate<ItemStack> isValid = stack ->
+				!stack.isEmpty()
+				&& stack.getItem() instanceof IChargeable
+				&& !isInvalid.test(stack);
+
+		Inventory inv = player.getInventory();
+		List<ItemStack> result = new ArrayList<>();
+
+		for (int i = 0; i < 9; i++)
+		{
+			ItemStack s = inv.items.get(i);
+			if (isValid.test(s)) result.add(s);
+		}
+
+		List<ItemStack> curios = ItemChargeHelper.getChargeCurios(player);
+		curios.removeIf(isInvalid);
+		result.addAll(curios);
+
+		for (ItemStack s : inv.armor)
+		{
+			if (isValid.test(s)) result.add(s);
+		}
+
+		for (int i = 9; i < inv.items.size(); i++)
+		{
+			ItemStack s = inv.items.get(i);
+			if (isValid.test(s)) result.add(s);
+		}
+
+		return result;
 	}
 }


### PR DESCRIPTION
Closes #99

## Summary
- **Fix stranded charge bug**: multi-draw now spans multiple metalminds to satisfy a full cost; never partially applies (all-or-nothing)
- **Fix selection order**: hotbar → curios → armor → inventory (previously hotbar → inventory → armor → curios)
- **Two-pass design**: pass 1 is a read-only affordability check that collects accessible metalminds; pass 2 applies charge and attunement side-effects only if the full cost can be met
- **Dead code removal**: removed `adjustChargeExact` overloads with no external callers

## Test plan
- [ ] Tap a metal with charge spread across multiple metalminds — verify full cost is drawn and no charge is stranded
- [ ] Verify a tap that cannot be fully satisfied does not partially drain any metalmind
- [ ] Verify hotbar metalminds are preferred over inventory metalminds
- [ ] Verify curios slots are checked before armor and main inventory
- [ ] Verify attuned/unkeyed metalmind access rules still work correctly (own metalmind, unkeyed with/without identity)
- [ ] Verify storing identity (aluminum feruchemy) still allows storing in unkeyed metalminds
- [ ] Verify tin zoom render check (simulate=true) does not consume charge

🤖 Generated with [Claude Code](https://claude.com/claude-code)