### PR TITLE
[Feruchemy] BugFix: Providing a Position in canSleep in FeruchemyBronze. 

### DIFF
--- a/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyBronze.java
+++ b/src/feruchemy/java/leaf/cosmere/feruchemy/common/manifestation/FeruchemyBronze.java
@@ -1,5 +1,5 @@
 /*
- * File updated ~ 9 - 8 - 2024 ~ Leaf
+ * File updated ~ 30 - 5 - 2026 ~ EdgarVerdi
  */
 
 package leaf.cosmere.feruchemy.common.manifestation;
@@ -144,7 +144,7 @@ public class FeruchemyBronze extends FeruchemyManifestation
 
 	private boolean canSleep(Player player)
 	{
-		Player.BedSleepingProblem ret = ForgeEventFactory.onPlayerSleepInBed(player, Optional.empty());
+		Player.BedSleepingProblem ret = ForgeEventFactory.onPlayerSleepInBed(player, Optional.of(player.blockPosition()));
 		if (ret != null)
 		{
 			return false;


### PR DESCRIPTION
## Changes proposed in this pull request:
- bug fix: provided a position in onPlayerSleepInBed of canSleep in FeruchemyBronze. This should prevent other mods from crashing when trying to access a non-null event.getPos() when using onTrySleep(PlayerSleepInBedEvent event)

## Testing checklist:

- [ ] yes I tested this in a `runServer` environment, and therefore won't make leaf cry
- [ ] yes, I actually connected to that server and verified it worked and don't need to have my kneecaps removed
- [x] yes, I also tested the built jars manually outside of the development environment, because problems sometimes don't show up inside the dev environment.
